### PR TITLE
Use tools lib to handle waiting for dev app server to start

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -95,21 +95,23 @@
           <target>1.7</target>
         </configuration>
       </plugin>
-      <!-- Work around a performance issue with Maven and Java 7:
-        Maven has a dependency that does a getgrgid for each file.
-        This is very slow for large groups, and not cached.
-        See issue: http://jira.codehaus.org/browse/PLXCOMP-203
-      -->
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jar-plugin</artifactId>
-        <dependencies>
-          <dependency>
-            <groupId>org.codehaus.plexus</groupId>
-            <artifactId>plexus-io</artifactId>
-            <version>2.0.5</version>
-          </dependency>
-        </dependencies>
+        <version>2.3</version>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-source-plugin</artifactId>
+        <version>2.1.2</version>
+        <executions>
+          <execution>
+            <id>attach-sources</id>
+            <goals>
+              <goal>jar</goal>
+            </goals>
+          </execution>
+        </executions>
       </plugin>
       <plugin>
         <artifactId>maven-checkstyle-plugin</artifactId>

--- a/src/main/java/com/google/cloud/tools/maven/CloudSdkMojo.java
+++ b/src/main/java/com/google/cloud/tools/maven/CloudSdkMojo.java
@@ -50,8 +50,8 @@ public abstract class CloudSdkMojo extends AbstractMojo {
 
     cloudSdkBuilder = new CloudSdk.Builder()
         .sdkPath(cloudSdkPath)
-        .stdOutLineListener(gcloudOutputListener)
-        .stdErrLineListener(gcloudOutputListener);
+        .addStdOutLineListener(gcloudOutputListener)
+        .addStdErrLineListener(gcloudOutputListener);
   }
 
   protected CloudSdk getCloudSdk() {

--- a/src/main/java/com/google/cloud/tools/maven/CloudSdkMojo.java
+++ b/src/main/java/com/google/cloud/tools/maven/CloudSdkMojo.java
@@ -17,7 +17,6 @@
 
 package com.google.cloud.tools.maven;
 
-import com.google.cloud.tools.app.impl.cloudsdk.internal.process.DefaultProcessRunner;
 import com.google.cloud.tools.app.impl.cloudsdk.internal.process.ProcessOutputLineListener;
 import com.google.cloud.tools.app.impl.cloudsdk.internal.sdk.CloudSdk;
 
@@ -38,9 +37,8 @@ public abstract class CloudSdkMojo extends AbstractMojo {
   protected File cloudSdkPath;
 
   protected CloudSdk.Builder cloudSdkBuilder;
-  protected DefaultProcessRunner.Builder processRunnerBuilder;
 
-  final private ProcessOutputLineListener gcloudOutputListener = new ProcessOutputLineListener() {
+  private final ProcessOutputLineListener gcloudOutputListener = new ProcessOutputLineListener() {
     @Override
     public void outputLine(String line) {
       System.out.println("GCLOUD: " + line);
@@ -50,15 +48,13 @@ public abstract class CloudSdkMojo extends AbstractMojo {
   protected CloudSdkMojo() {
     super();
 
-    cloudSdkBuilder = new CloudSdk.Builder().sdkPath(cloudSdkPath);
-    processRunnerBuilder = new DefaultProcessRunner.Builder()
+    cloudSdkBuilder = new CloudSdk.Builder()
+        .sdkPath(cloudSdkPath)
         .stdOutLineListener(gcloudOutputListener)
         .stdErrLineListener(gcloudOutputListener);
   }
 
   protected CloudSdk getCloudSdk() {
-    return new CloudSdk.Builder()
-        .processRunner(processRunnerBuilder.build())
-        .build();
+    return cloudSdkBuilder.build();
   }
 }

--- a/src/main/java/com/google/cloud/tools/maven/CloudSdkMojo.java
+++ b/src/main/java/com/google/cloud/tools/maven/CloudSdkMojo.java
@@ -41,7 +41,7 @@ public abstract class CloudSdkMojo extends AbstractMojo {
   private final ProcessOutputLineListener gcloudOutputListener = new ProcessOutputLineListener() {
     @Override
     public void outputLine(String line) {
-      System.out.println("GCLOUD: " + line);
+      getLog().info("GCLOUD: " + line);
     }
   };
 

--- a/src/main/java/com/google/cloud/tools/maven/CloudSdkMojo.java
+++ b/src/main/java/com/google/cloud/tools/maven/CloudSdkMojo.java
@@ -18,11 +18,10 @@
 package com.google.cloud.tools.maven;
 
 import com.google.cloud.tools.app.impl.cloudsdk.internal.process.DefaultProcessRunner;
+import com.google.cloud.tools.app.impl.cloudsdk.internal.process.ProcessOutputLineListener;
 import com.google.cloud.tools.app.impl.cloudsdk.internal.sdk.CloudSdk;
 
 import org.apache.maven.plugin.AbstractMojo;
-import org.apache.maven.plugin.MojoExecutionException;
-import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.Parameter;
 
 import java.io.File;
@@ -38,15 +37,28 @@ public abstract class CloudSdkMojo extends AbstractMojo {
   @Parameter(property = "cloudSdkPath", required = false)
   protected File cloudSdkPath;
 
-  protected CloudSdk cloudSdk;
+  protected CloudSdk.Builder cloudSdkBuilder;
+  protected DefaultProcessRunner.Builder processRunnerBuilder;
 
-  protected DefaultProcessRunner processRunner;
+  final private ProcessOutputLineListener gcloudOutputListener = new ProcessOutputLineListener() {
+    @Override
+    public void outputLine(String line) {
+      System.out.println("GCLOUD: " + line);
+    }
+  };
 
-  @Override
-  public void execute() throws MojoExecutionException, MojoFailureException {
-    this.cloudSdk = new CloudSdk.Builder()
-        .processRunner(processRunner)
-        .sdkPath(cloudSdkPath)
+  protected CloudSdkMojo() {
+    super();
+
+    cloudSdkBuilder = new CloudSdk.Builder().sdkPath(cloudSdkPath);
+    processRunnerBuilder = new DefaultProcessRunner.Builder()
+        .stdOutLineListener(gcloudOutputListener)
+        .stdErrLineListener(gcloudOutputListener);
+  }
+
+  protected CloudSdk getCloudSdk() {
+    return new CloudSdk.Builder()
+        .processRunner(processRunnerBuilder.build())
         .build();
   }
 }

--- a/src/main/java/com/google/cloud/tools/maven/DeployMojo.java
+++ b/src/main/java/com/google/cloud/tools/maven/DeployMojo.java
@@ -117,7 +117,7 @@ public class DeployMojo extends StageMojo implements DeployConfiguration {
           new File(getStagingDirectory() + "/app.yaml"));
     }
 
-    AppEngineDeployment deployment = new CloudSdkAppEngineDeployment(cloudSdk);
+    AppEngineDeployment deployment = new CloudSdkAppEngineDeployment(getCloudSdk());
     deployment.deploy(this);
   }
 

--- a/src/main/java/com/google/cloud/tools/maven/RunAsyncMojo.java
+++ b/src/main/java/com/google/cloud/tools/maven/RunAsyncMojo.java
@@ -16,9 +16,6 @@
 
 package com.google.cloud.tools.maven;
 
-import com.google.cloud.tools.app.impl.cloudsdk.internal.process.ProcessRunnerException;
-import com.google.cloud.tools.app.impl.cloudsdk.internal.process.WaitingProcessOutputLineListener;
-
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.Execute;
@@ -42,23 +39,15 @@ public class RunAsyncMojo extends RunMojo {
 
   @Override
   public void execute() throws MojoExecutionException, MojoFailureException {
-    WaitingProcessOutputLineListener startListener =
-        new WaitingProcessOutputLineListener("Dev App Server is now running", startSuccessTimeout);
 
     cloudSdkBuilder
         .async(true)
-        .addStdErrLineListener(startListener)
-        .addStdOutLineListener(startListener);
+        .runDevAppServerWait(startSuccessTimeout);
+
+    getLog().info("Waiting " + startSuccessTimeout + " seconds for the Dev App Server to start.");
 
     super.execute();
 
-    // wait for the server to start
-    try {
-      getLog().info("Waiting " + startSuccessTimeout + " seconds for the Dev App Server to start.");
-      startListener.await();
-      getLog().info("Dev App Server started.");
-    } catch (ProcessRunnerException | InterruptedException e) {
-      throw new MojoExecutionException("Dev App Server failed to start.", e);
-    }
+    getLog().info("Dev App Server started.");
   }
 }

--- a/src/main/java/com/google/cloud/tools/maven/RunAsyncMojo.java
+++ b/src/main/java/com/google/cloud/tools/maven/RunAsyncMojo.java
@@ -16,11 +16,12 @@
 
 package com.google.cloud.tools.maven;
 
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.Execute;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
-
-import java.util.concurrent.CountDownLatch;
+import org.apache.maven.plugins.annotations.Parameter;
 
 /**
  * Starts running App Engine Development App Server asynchronously.
@@ -29,14 +30,22 @@ import java.util.concurrent.CountDownLatch;
 @Execute(phase = LifecyclePhase.PACKAGE)
 public class RunAsyncMojo extends RunMojo {
 
-  private CountDownLatch waitStartedLatch;
-
   /**
-   * Configures an asynchronous process runner for running server.
+   * Number of seconds to wait for the server to start. Set to 0 to not wait.
    */
-  public RunAsyncMojo() {
-    super();
-    processRunner.setAsync(true);
-  }
+  @Parameter(defaultValue = "30",
+      alias = "devserver.startSuccessTimeout", property = "app.devserver.startSuccessTimeout")
+  protected int startSuccessTimeout;
 
+  @Override
+  public void execute() throws MojoExecutionException, MojoFailureException {
+    processRunnerBuilder
+        .async(true)
+        .waitSuccessMessage("Dev App Server is now running")
+        .waitSuccessTimeoutSeconds(startSuccessTimeout);
+
+    super.execute();
+
+    getLog().info("Dev App Server started.");
+  }
 }

--- a/src/main/java/com/google/cloud/tools/maven/RunAsyncMojo.java
+++ b/src/main/java/com/google/cloud/tools/maven/RunAsyncMojo.java
@@ -39,7 +39,7 @@ public class RunAsyncMojo extends RunMojo {
 
   @Override
   public void execute() throws MojoExecutionException, MojoFailureException {
-    processRunnerBuilder
+    cloudSdkBuilder
         .async(true)
         .waitSuccessMessage("Dev App Server is now running")
         .waitSuccessTimeoutSeconds(startSuccessTimeout);

--- a/src/main/java/com/google/cloud/tools/maven/RunMojo.java
+++ b/src/main/java/com/google/cloud/tools/maven/RunMojo.java
@@ -20,8 +20,6 @@ package com.google.cloud.tools.maven;
 import com.google.cloud.tools.app.api.devserver.AppEngineDevServer;
 import com.google.cloud.tools.app.api.devserver.RunConfiguration;
 import com.google.cloud.tools.app.impl.cloudsdk.CloudSdkAppEngineDevServer;
-import com.google.cloud.tools.app.impl.cloudsdk.internal.process.DefaultProcessRunner;
-import com.google.cloud.tools.app.impl.cloudsdk.internal.process.ProcessOutputLineListener;
 
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
@@ -32,8 +30,6 @@ import org.apache.maven.plugins.annotations.Parameter;
 
 import java.io.File;
 import java.util.List;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
 
 /**
  * Run App Engine Development App Server synchronously.
@@ -199,51 +195,12 @@ public class RunMojo extends CloudSdkMojo implements RunConfiguration {
       property = "app.devserver.defaultGcsBucketName")
   protected String defaultGcsBucketName;
 
-  private CountDownLatch waitStartedLatch;
-
-  /**
-   * Sets up a process runner for synchronous execution and creates a listener for waiting for Dev
-   * App Server to start.
-   */
-  public RunMojo() {
-    super();
-
-    processRunner = new DefaultProcessRunner(
-        new ProcessBuilder().redirectErrorStream(true));
-    processRunner.setAsync(false);
-
-    ProcessOutputLineListener listener = new ProcessOutputLineListener() {
-      @Override
-      public void outputLine(String line) {
-        if (line.contains("Dev App Server is now running")) {
-          getLog().info("Dev App Server started.");
-          waitStartedLatch.countDown();
-        }
-        getLog().info(line);
-      }
-    };
-    processRunner.setStdOutLineListener(listener);
-  }
 
   @Override
   public void execute() throws MojoExecutionException, MojoFailureException {
-    super.execute();
+    AppEngineDevServer devServer = new CloudSdkAppEngineDevServer(getCloudSdk());
 
-    waitStartedLatch = new CountDownLatch(1);
-
-    AppEngineDevServer devServer = new CloudSdkAppEngineDevServer(cloudSdk);
-
-    try {
-      devServer.run(this);
-      if (!waitStartedLatch.await(10, TimeUnit.SECONDS)) {
-        getLog().error("Timed out waiting to start App Engine Development server");
-      }
-    } catch (InterruptedException e) {
-      throw new MojoExecutionException("Failed to start the App Engine Development server.", e);
-    } finally {
-      waitStartedLatch.countDown();
-    }
-
+    devServer.run(this);
   }
 
   @Override

--- a/src/main/java/com/google/cloud/tools/maven/StageMojo.java
+++ b/src/main/java/com/google/cloud/tools/maven/StageMojo.java
@@ -162,7 +162,6 @@ public class StageMojo extends CloudSdkMojo implements StageStandardConfiguratio
 
   @Override
   public void execute() throws MojoExecutionException, MojoFailureException {
-    super.execute();
 
     // delete staging directory if it exists
     if (stagingDirectory.exists()) {
@@ -187,7 +186,7 @@ public class StageMojo extends CloudSdkMojo implements StageStandardConfiguratio
   }
 
   private void stageStandard() {
-    CloudSdkAppEngineStandardStaging staging = new CloudSdkAppEngineStandardStaging(cloudSdk);
+    CloudSdkAppEngineStandardStaging staging = new CloudSdkAppEngineStandardStaging(getCloudSdk());
 
     // execute the staging
     staging.stageStandard(this);

--- a/src/main/java/com/google/cloud/tools/maven/StopMojo.java
+++ b/src/main/java/com/google/cloud/tools/maven/StopMojo.java
@@ -45,9 +45,7 @@ public class StopMojo extends CloudSdkMojo implements StopConfiguration {
 
   @Override
   public void execute() throws MojoExecutionException, MojoFailureException {
-    super.execute();
-
-    AppEngineDevServer devServer = new CloudSdkAppEngineDevServer(cloudSdk);
+    AppEngineDevServer devServer = new CloudSdkAppEngineDevServer(getCloudSdk());
 
     devServer.stop(this);
   }


### PR DESCRIPTION
The functionality to wait for an async process to start successfully has been moved to the common tools library. See: https://github.com/GoogleCloudPlatform/app-tools-lib-for-java/pull/67.

Also, changed pom.xml to generated sources jar and to run faster.