### PR TITLE
Set env var and tag plugin identify for metrics

### DIFF
--- a/src/main/java/com/google/cloud/tools/maven/CloudSdkMojo.java
+++ b/src/main/java/com/google/cloud/tools/maven/CloudSdkMojo.java
@@ -50,6 +50,7 @@ public abstract class CloudSdkMojo extends AbstractMojo {
 
     cloudSdkBuilder = new CloudSdk.Builder()
         .sdkPath(cloudSdkPath)
+        .appCommandMetricsEnvironment("app-maven-plugin")
         .addStdOutLineListener(gcloudOutputListener)
         .addStdErrLineListener(gcloudOutputListener);
   }

--- a/src/main/java/com/google/cloud/tools/maven/CloudSdkMojo.java
+++ b/src/main/java/com/google/cloud/tools/maven/CloudSdkMojo.java
@@ -60,7 +60,6 @@ public abstract class CloudSdkMojo extends AbstractMojo {
   }
 
   protected CloudSdk getCloudSdk() {
-    System.out.println(pluginDescriptor.getArtifactId() + " : " + pluginDescriptor.getVersion());
     return cloudSdkBuilder
         .appCommandMetricsEnvironment(pluginDescriptor.getArtifactId())
         .appCommandMetricsEnvironmentVersion(pluginDescriptor.getVersion())

--- a/src/main/java/com/google/cloud/tools/maven/CloudSdkMojo.java
+++ b/src/main/java/com/google/cloud/tools/maven/CloudSdkMojo.java
@@ -21,6 +21,8 @@ import com.google.cloud.tools.app.impl.cloudsdk.internal.process.ProcessOutputLi
 import com.google.cloud.tools.app.impl.cloudsdk.internal.sdk.CloudSdk;
 
 import org.apache.maven.plugin.AbstractMojo;
+import org.apache.maven.plugin.descriptor.PluginDescriptor;
+import org.apache.maven.plugins.annotations.Component;
 import org.apache.maven.plugins.annotations.Parameter;
 
 import java.io.File;
@@ -45,17 +47,23 @@ public abstract class CloudSdkMojo extends AbstractMojo {
     }
   };
 
+  @Component
+  private PluginDescriptor pluginDescriptor;
+
   protected CloudSdkMojo() {
     super();
 
     cloudSdkBuilder = new CloudSdk.Builder()
         .sdkPath(cloudSdkPath)
-        .appCommandMetricsEnvironment("app-maven-plugin")
         .addStdOutLineListener(gcloudOutputListener)
         .addStdErrLineListener(gcloudOutputListener);
   }
 
   protected CloudSdk getCloudSdk() {
-    return cloudSdkBuilder.build();
+    System.out.println(pluginDescriptor.getArtifactId() + " : " + pluginDescriptor.getVersion());
+    return cloudSdkBuilder
+        .appCommandMetricsEnvironment(pluginDescriptor.getArtifactId())
+        .appCommandMetricsEnvironmentVersion(pluginDescriptor.getVersion())
+        .build();
   }
 }


### PR DESCRIPTION
In relation to #4.

I'd like to set this now so that we don't forget it before the next release. How about "app-maven-plugin"?

Note: we still need to set ENVIRONMENT_VERSION.