### PR TITLE
use travis_wait 30 to increase no output timeout to 30 mins

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ install:
 script:
   - |
     if $INCLUDE_REMOTE_TESTS; then
-      mvn clean deploy --settings .travis/settings.xml -B -U -P include-remote-tests
+      travis_wait 30 mvn clean deploy --settings .travis/settings.xml -B -U -P include-remote-tests
     else
       mvn clean install -B -U
     fi


### PR DESCRIPTION
The default timeout is 10 minutes, but the deployment test can sometimes take longer without producing any output to the console.

@loosebazooka 