### PR TITLE
Update to Plugins Core 0.1.5-SNAPSHOT and disable Travis remote tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,13 +19,13 @@ install:
   # only run remote tests on master branch
   - |
     if [ $TRAVIS_PULL_REQUEST = 'false' ] && [ $TRAVIS_BRANCH = 'master' ]; then
-      export INCLUDE_REMOTE_TESTS=true
+      export DO_DEPLOY=true
     else
-      export INCLUDE_REMOTE_TESTS=false
+      export DO_DEPLOY=false
     fi
-  - echo INCLUDE_REMOTE_TESTS = $INCLUDE_REMOTE_TESTS
+  - echo DO_DEPLOY = $DO_DEPLOY
   - |
-    if $INCLUDE_REMOTE_TESTS; then
+    if $DO_DEPLOY; then
       # decrypt the tavis-app-maven-plugin Cloud SDK project service account key
       openssl aes-256-cbc -K $encrypted_4c3a51657fee_key -iv $encrypted_4c3a51657fee_iv -in config/travis-app-maven-plugin-e1bb638f290e.json.enc -out config/travis-app-maven-plugin-e1bb638f290e.json -d
       # set Cloud SDK CLI authentication
@@ -36,7 +36,7 @@ install:
 
 script:
   - |
-    if $INCLUDE_REMOTE_TESTS; then
+    if $DO_DEPLOY; then
       mvn clean deploy --settings .travis/settings.xml -B -U
     else
       mvn clean install -B -U

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ install:
 script:
   - |
     if $INCLUDE_REMOTE_TESTS; then
-      travis_wait 30 mvn clean deploy --settings .travis/settings.xml -B -U
+      mvn clean deploy --settings .travis/settings.xml -B -U
     else
       mvn clean install -B -U
     fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ install:
 script:
   - |
     if $INCLUDE_REMOTE_TESTS; then
-      travis_wait 30 mvn clean deploy --settings .travis/settings.xml -B -U -P include-remote-tests
+      travis_wait 30 mvn clean deploy --settings .travis/settings.xml -B -U
     else
       mvn clean install -B -U
     fi

--- a/pom.xml
+++ b/pom.xml
@@ -105,7 +105,7 @@
     <dependency>
       <groupId>com.google.cloud.tools</groupId>
       <artifactId>appengine-plugins-core</artifactId>
-      <version>0.1.4</version>
+      <version>0.1.5-SNAPSHOT</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
The Travis deploy test is still unreliable. Removing it until the issue is resolved.

@loosebazooka PTAL