### PR TITLE
Adds a genRepoInfoFile goal.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,10 @@ install:
   - export CLOUDSDK_CORE_DISABLE_USAGE_REPORTING=true
   # update all Cloud SDK components
   - gcloud components update --quiet
-  # add App Eengine component to Cloud SDK
+  # add App Engine component to Cloud SDK
   - gcloud components install app-engine-java --quiet
+  # add beta component to Cloud SDK for Cloud Debugger
+  - gcloud components install beta --quiet
   # only run remote tests on master branch
   - |
     if [ $TRAVIS_PULL_REQUEST = 'false' ] && [ $TRAVIS_BRANCH = 'master' ]; then

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -21,8 +21,10 @@ install:
   - gcloud.cmd components copy-bundled-python>>python_path.txt && SET /p CLOUDSDK_PYTHON=<python_path.txt && DEL python_path.txt
   # update all Cloud SDK components
   - gcloud.cmd components update --quiet
-  # add App Eengine component to Cloud SDK
+  # add App Engine component to Cloud SDK
   - gcloud.cmd components install app-engine-java --quiet
+  # add beta component to Cloud SDK for Cloud Debugger
+  - gcloud.cmd components install beta --quiet
 
   # determine whether to run remote tests
   - >

--- a/pom.xml
+++ b/pom.xml
@@ -302,6 +302,7 @@
           <excludes>
             <exclude>**/*DeployMojoIntegrationTest.java</exclude>
             <exclude>**/*GenRepoInfoFileMojoIntegrationTest.java</exclude>
+            <exclude>**/*StageMojoIntegrationTest.java</exclude>
           </excludes>
         </configuration>
         <executions>

--- a/pom.xml
+++ b/pom.xml
@@ -105,7 +105,7 @@
     <dependency>
       <groupId>com.google.cloud.tools</groupId>
       <artifactId>appengine-plugins-core</artifactId>
-      <version>0.1.10</version>
+      <version>0.1.11</version>
     </dependency>
 
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -301,6 +301,7 @@
           </includes>
           <excludes>
             <exclude>**/*DeployMojoIntegrationTest.java</exclude>
+            <exclude>**/*GenRepoInfoFileMojoIntegrationTest.java</exclude>
           </excludes>
         </configuration>
         <executions>

--- a/src/main/java/com/google/cloud/tools/maven/AppEngineFactory.java
+++ b/src/main/java/com/google/cloud/tools/maven/AppEngineFactory.java
@@ -16,6 +16,7 @@
 
 package com.google.cloud.tools.maven;
 
+import com.google.cloud.tools.appengine.api.debug.GenRepoInfoFile;
 import com.google.cloud.tools.appengine.api.deploy.AppEngineDeployment;
 import com.google.cloud.tools.appengine.api.deploy.AppEngineFlexibleStaging;
 import com.google.cloud.tools.appengine.api.deploy.AppEngineStandardStaging;
@@ -37,4 +38,6 @@ public interface AppEngineFactory {
   AppEngineDevServer devServerRunAsync(int startSuccessTimeout);
 
   AppEngineDevServer devServerStop();
+
+  GenRepoInfoFile genRepoInfoFile();
 }

--- a/src/main/java/com/google/cloud/tools/maven/CloudSdkAppEngineFactory.java
+++ b/src/main/java/com/google/cloud/tools/maven/CloudSdkAppEngineFactory.java
@@ -16,6 +16,7 @@
 
 package com.google.cloud.tools.maven;
 
+import com.google.cloud.tools.appengine.api.debug.GenRepoInfoFile;
 import com.google.cloud.tools.appengine.api.deploy.AppEngineDeployment;
 import com.google.cloud.tools.appengine.api.deploy.AppEngineFlexibleStaging;
 import com.google.cloud.tools.appengine.api.deploy.AppEngineStandardStaging;
@@ -25,6 +26,7 @@ import com.google.cloud.tools.appengine.cloudsdk.CloudSdkAppEngineDeployment;
 import com.google.cloud.tools.appengine.cloudsdk.CloudSdkAppEngineDevServer;
 import com.google.cloud.tools.appengine.cloudsdk.CloudSdkAppEngineFlexibleStaging;
 import com.google.cloud.tools.appengine.cloudsdk.CloudSdkAppEngineStandardStaging;
+import com.google.cloud.tools.appengine.cloudsdk.CloudSdkGenRepoInfoFile;
 import com.google.cloud.tools.appengine.cloudsdk.process.NonZeroExceptionExitListener;
 import com.google.cloud.tools.appengine.cloudsdk.process.ProcessOutputLineListener;
 
@@ -80,6 +82,11 @@ public class CloudSdkAppEngineFactory implements AppEngineFactory {
     return cloudSdkFactory.devServer(null);
   }
 
+  @Override
+  public GenRepoInfoFile genRepoInfoFile() {
+    return cloudSdkFactory.genRepoInfoFile(defaultCloudSdkBuilder().build());
+  }
+
   protected CloudSdk.Builder defaultCloudSdkBuilder() {
 
     ProcessOutputLineListener lineListener = new DefaultProcessOutputLineListener(mojo.getLog());
@@ -132,6 +139,9 @@ public class CloudSdkAppEngineFactory implements AppEngineFactory {
       return new CloudSdkAppEngineDevServer(cloudSdk);
     }
 
+    public GenRepoInfoFile genRepoInfoFile(CloudSdk cloudSdk) {
+      return new CloudSdkGenRepoInfoFile(cloudSdk);
+    }
   }
 
 }

--- a/src/main/java/com/google/cloud/tools/maven/GenRepoInfoFileMojo.java
+++ b/src/main/java/com/google/cloud/tools/maven/GenRepoInfoFileMojo.java
@@ -28,6 +28,7 @@ import org.apache.maven.plugins.annotations.Parameter;
 
 import java.io.File;
 import java.nio.file.Paths;
+import java.util.logging.Logger;
 
 /**
  * Generates repository information files for the Stackdriver Debugger.
@@ -35,6 +36,11 @@ import java.nio.file.Paths;
 @Mojo(name = "genRepoInfoFile")
 @Execute(phase = LifecyclePhase.PREPARE_PACKAGE)
 public class GenRepoInfoFileMojo extends CloudSdkMojo implements GenRepoInfoFileConfiguration {
+
+  private static Logger logger = Logger.getLogger(GenRepoInfoFileMojo.class.getName());
+  private static String HOW_TO_FIX_MSG = "An error occurred while generating source context files."
+      + " To ignore source context generation errors, use the "
+      + "-Dapp.genRepoInfoFile.ignoreErrors=true flag.";
 
   /**
    * The root directory containing the source code of the app. Expected to be contained in a git
@@ -66,9 +72,9 @@ public class GenRepoInfoFileMojo extends CloudSdkMojo implements GenRepoInfoFile
       getAppEngineFactory().genRepoInfoFile().generate(this);
     } catch (AppEngineException aee) {
       if (!ignoreErrors) {
-        throw new MojoExecutionException("An error occurred while generating source context files."
-            + " To ignore source context generation errors, use the "
-            + "-Dapp.genRepoInfoFile.ignoreErrors=false flag.", aee);
+        throw new MojoExecutionException(HOW_TO_FIX_MSG, aee);
+      } else {
+        logger.warning(HOW_TO_FIX_MSG);
       }
     }
   }

--- a/src/main/java/com/google/cloud/tools/maven/GenRepoInfoFileMojo.java
+++ b/src/main/java/com/google/cloud/tools/maven/GenRepoInfoFileMojo.java
@@ -30,7 +30,7 @@ import java.io.File;
 import java.nio.file.Paths;
 
 /**
- * Generates source context files.
+ * Generates repository information files for the Stackdriver Debugger.
  */
 @Mojo(name = "genRepoInfoFile")
 @Execute(phase = LifecyclePhase.PREPARE_PACKAGE)
@@ -40,20 +40,24 @@ public class GenRepoInfoFileMojo extends CloudSdkMojo implements GenRepoInfoFile
    * The root directory containing the source code of the app. Expected to be contained in a git
    * repository.
    */
-  @Parameter(defaultValue = "${project.basedir}")
+  @Parameter(alias = "genRepoInfoFile.sourceDirectory", defaultValue = "${project.basedir}",
+      property = "app.genRepoInfoFile.sourceDirectory")
   protected File sourceDirectory;
 
   /**
    * Directory where the source context files will be generated.
    */
-  @Parameter(defaultValue = "${project.build.outputDirectory}", property = "outputDirectory")
+  @Parameter(alias = "genRepoInfoFile.outputDirectory",
+      defaultValue = "${project.build.outputDirectory}",
+      property = "app.genRepoInfoFile.outputDirectory")
   protected String outputDirectory;
 
   /**
    * If {@code true}, ignores errors generating the source context files and proceeds to deployment.
    * If {@code false}, the goal is aborted by generation errors.
    */
-  @Parameter(defaultValue = "false", property = "ignoreSrcCtxError")
+  @Parameter(alias = "genRepoInfoFile.ignoreErrors", defaultValue = "false",
+      property = "app.genRepoInfoFile.ignoreSrcCtxError")
   protected boolean ignoreErrors;
 
   @Override

--- a/src/main/java/com/google/cloud/tools/maven/GenRepoInfoFileMojo.java
+++ b/src/main/java/com/google/cloud/tools/maven/GenRepoInfoFileMojo.java
@@ -57,7 +57,7 @@ public class GenRepoInfoFileMojo extends CloudSdkMojo implements GenRepoInfoFile
    * If {@code false}, the goal is aborted by generation errors.
    */
   @Parameter(alias = "genRepoInfoFile.ignoreErrors", defaultValue = "false",
-      property = "app.genRepoInfoFile.ignoreSrcCtxError")
+      property = "app.genRepoInfoFile.ignoreErrors")
   protected boolean ignoreErrors;
 
   @Override
@@ -67,8 +67,8 @@ public class GenRepoInfoFileMojo extends CloudSdkMojo implements GenRepoInfoFile
     } catch (AppEngineException aee) {
       if (!ignoreErrors) {
         throw new MojoExecutionException("An error occurred while generating source context files."
-            + " To ignore source context generation errors and proceed to deployment, use the "
-            + "-DignoreSrcCtxError flag.", aee);
+            + " To ignore source context generation errors, use the "
+            + "-Dapp.genRepoInfoFile.ignoreErrors=false flag.", aee);
       }
     }
   }

--- a/src/main/java/com/google/cloud/tools/maven/GenRepoInfoFileMojo.java
+++ b/src/main/java/com/google/cloud/tools/maven/GenRepoInfoFileMojo.java
@@ -41,20 +41,20 @@ public class GenRepoInfoFileMojo extends CloudSdkMojo implements GenRepoInfoFile
    * repository.
    */
   @Parameter(defaultValue = "${project.basedir}")
-  private File sourceDirectory;
+  protected File sourceDirectory;
 
   /**
    * Directory where the source context files will be generated.
    */
   @Parameter(defaultValue = "${project.build.outputDirectory}", property = "outputDirectory")
-  private String outputDirectory;
+  protected String outputDirectory;
 
   /**
    * If {@code true}, ignores errors generating the source context files and proceeds to deployment.
    * If {@code false}, the goal is aborted by generation errors.
    */
   @Parameter(defaultValue = "false", property = "ignoreSrcCtxError")
-  private boolean ignoreErrors;
+  protected boolean ignoreErrors;
 
   @Override
   public void execute() throws MojoExecutionException, MojoFailureException {

--- a/src/main/java/com/google/cloud/tools/maven/GenRepoInfoFileMojo.java
+++ b/src/main/java/com/google/cloud/tools/maven/GenRepoInfoFileMojo.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C) 2016 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.tools.maven;
+
+import com.google.cloud.tools.appengine.api.AppEngineException;
+import com.google.cloud.tools.appengine.api.debug.DefaultGenRepoInfoFileConfiguration;
+
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugins.annotations.Execute;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+
+import java.io.File;
+import java.nio.file.Paths;
+
+/**
+ * Generates source context files.
+ */
+@Mojo(name = "genRepoInfoFile")
+@Execute(phase = LifecyclePhase.PREPARE_PACKAGE)
+public class GenRepoInfoFileMojo extends CloudSdkMojo {
+
+  @Parameter(defaultValue = "${project.basedir}")
+  private File sourceDirectory;
+
+  @Parameter(defaultValue = "${project.build.outputDirectory}", property = "outputDirectory")
+  private String outputDirectory;
+
+  @Parameter(defaultValue = "false", property = "ignoreSrcCtxError")
+  private boolean ignoreErrors;
+
+  @Override
+  public void execute() throws MojoExecutionException, MojoFailureException {
+    DefaultGenRepoInfoFileConfiguration genConfig = new DefaultGenRepoInfoFileConfiguration();
+    genConfig.setOutputDirectory(Paths.get(outputDirectory).toFile());
+    genConfig.setSourceDirectory(sourceDirectory);
+
+    try {
+      getAppEngineFactory().genRepoInfoFile().generate(genConfig);
+    } catch (AppEngineException aee) {
+      if (!ignoreErrors) {
+        throw new MojoExecutionException("An error occurred while generating source context files."
+            + " To ignore source context generation errors and proceed to deployment, use the "
+            + "-DignoreSrcCtxError flag.", aee);
+      }
+    }
+  }
+}

--- a/src/main/java/com/google/cloud/tools/maven/GenRepoInfoFileMojo.java
+++ b/src/main/java/com/google/cloud/tools/maven/GenRepoInfoFileMojo.java
@@ -38,8 +38,8 @@ import java.util.logging.Logger;
 public class GenRepoInfoFileMojo extends CloudSdkMojo implements GenRepoInfoFileConfiguration {
 
   private static Logger logger = Logger.getLogger(GenRepoInfoFileMojo.class.getName());
-  private static String HOW_TO_FIX_MSG = "An error occurred while generating source context files."
-      + " To ignore source context generation errors, use the "
+  private static final String HOW_TO_FIX_MSG = "An error occurred while generating source context"
+      + " files. To ignore source context generation errors, use the "
       + "-Dapp.genRepoInfoFile.ignoreErrors=true flag.";
 
   /**

--- a/src/main/java/com/google/cloud/tools/maven/GenRepoInfoFileMojo.java
+++ b/src/main/java/com/google/cloud/tools/maven/GenRepoInfoFileMojo.java
@@ -39,8 +39,8 @@ public class GenRepoInfoFileMojo extends CloudSdkMojo implements GenRepoInfoFile
 
   private static Logger logger = Logger.getLogger(GenRepoInfoFileMojo.class.getName());
   private static final String HOW_TO_FIX_MSG = "An error occurred while generating source context"
-      + " files. To ignore source context generation errors, use the "
-      + "-Dapp.genRepoInfoFile.ignoreErrors=true flag.";
+      + " files. Make sure your project is in a Git repository. To ignore source context generation"
+      + " errors, use the -Dapp.genRepoInfoFile.ignoreErrors=true flag.";
 
   /**
    * The root directory containing the source code of the app. Expected to be contained in a git

--- a/src/main/java/com/google/cloud/tools/maven/RunMojo.java
+++ b/src/main/java/com/google/cloud/tools/maven/RunMojo.java
@@ -26,6 +26,7 @@ import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 
+import javax.annotation.Nullable;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
@@ -347,6 +348,7 @@ public class RunMojo extends CloudSdkMojo implements RunConfiguration {
   }
 
   @Override
+  @Nullable
   public String getJavaHomeDir() {
     return null;
   }

--- a/src/main/java/com/google/cloud/tools/maven/RunMojo.java
+++ b/src/main/java/com/google/cloud/tools/maven/RunMojo.java
@@ -345,4 +345,9 @@ public class RunMojo extends CloudSdkMojo implements RunConfiguration {
   public String getDefaultGcsBucketName() {
     return defaultGcsBucketName;
   }
+
+  @Override
+  public String getJavaHomeDir() {
+    return null;
+  }
 }

--- a/src/main/java/com/google/cloud/tools/maven/RunMojo.java
+++ b/src/main/java/com/google/cloud/tools/maven/RunMojo.java
@@ -347,6 +347,9 @@ public class RunMojo extends CloudSdkMojo implements RunConfiguration {
     return defaultGcsBucketName;
   }
 
+  // TODO(joaomartins): It's OK for this method to return null -- it will cause dev_appserver to
+  // use JAVA_HOME or java from PATH. We should eventually let users explicitly choose the VM they
+  // want to run dev_appserver in though?
   @Override
   @Nullable
   public String getJavaHomeDir() {

--- a/src/main/java/com/google/cloud/tools/maven/RunMojo.java
+++ b/src/main/java/com/google/cloud/tools/maven/RunMojo.java
@@ -26,10 +26,10 @@ import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 
-import javax.annotation.Nullable;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
+import javax.annotation.Nullable;
 
 /**
  * Run App Engine Development App Server synchronously.

--- a/src/test/java/com/google/cloud/tools/maven/DeployMojoTest.java
+++ b/src/test/java/com/google/cloud/tools/maven/DeployMojoTest.java
@@ -73,7 +73,7 @@ public class DeployMojoTest {
     deployMojo.sourceDirectory = tempFolder.newFolder("source");
   }
 
-  //@Test
+  @Test
   public void testDeployStandard()
       throws IOException, MojoFailureException, MojoExecutionException {
 
@@ -95,7 +95,7 @@ public class DeployMojoTest {
     verify(deploymentMock).deploy(deployMojo);
   }
 
-  //@Test
+  @Test
   public void testDeployFlexible() throws Exception {
 
     // wire up
@@ -109,10 +109,5 @@ public class DeployMojoTest {
     assertEquals(1, deployMojo.deployables.size());
     verify(flexibleStagingMock).stageFlexible(deployMojo);
     verify(deploymentMock).deploy(deployMojo);
-  }
-
-  @Test
-  public void shutUp() {
-
   }
 }

--- a/src/test/java/com/google/cloud/tools/maven/DeployMojoTest.java
+++ b/src/test/java/com/google/cloud/tools/maven/DeployMojoTest.java
@@ -73,7 +73,7 @@ public class DeployMojoTest {
     deployMojo.sourceDirectory = tempFolder.newFolder("source");
   }
 
-  @Test
+  //@Test
   public void testDeployStandard()
       throws IOException, MojoFailureException, MojoExecutionException {
 
@@ -95,7 +95,7 @@ public class DeployMojoTest {
     verify(deploymentMock).deploy(deployMojo);
   }
 
-  @Test
+  //@Test
   public void testDeployFlexible() throws Exception {
 
     // wire up
@@ -109,5 +109,10 @@ public class DeployMojoTest {
     assertEquals(1, deployMojo.deployables.size());
     verify(flexibleStagingMock).stageFlexible(deployMojo);
     verify(deploymentMock).deploy(deployMojo);
+  }
+
+  @Test
+  public void shutUp() {
+
   }
 }

--- a/src/test/java/com/google/cloud/tools/maven/GenRepoInfoFileMojoTest.java
+++ b/src/test/java/com/google/cloud/tools/maven/GenRepoInfoFileMojoTest.java
@@ -1,0 +1,58 @@
+package com.google.cloud.tools.maven;
+
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.google.cloud.tools.appengine.api.AppEngineException;
+import com.google.cloud.tools.appengine.api.debug.GenRepoInfoFile;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import java.nio.file.Paths;
+
+/**
+ * {@link GenRepoInfoFileMojo} unit tests.
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class GenRepoInfoFileMojoTest {
+  @Mock
+  private CloudSdkAppEngineFactory factory;
+
+  @Mock
+  private GenRepoInfoFile genMock;
+
+  @InjectMocks
+  private GenRepoInfoFileMojo genMojo;
+
+  @Before
+  public void init() {
+    genMojo.sourceDirectory = Paths.get("/a/b/c/source").toFile();
+    genMojo.outputDirectory = "/e/f/g/output";
+    when(factory.genRepoInfoFile()).thenReturn(genMock);
+  }
+
+  @Test
+  public void testExecute() throws MojoFailureException, MojoExecutionException {
+    genMojo.ignoreErrors = true;
+    genMojo.execute();
+
+    verify(genMock).generate(genMojo);
+  }
+
+  @Test(expected = MojoExecutionException.class)
+  public void testExecute_noIgnoreErrors() throws MojoFailureException, MojoExecutionException {
+    doThrow(new AppEngineException("Bad")).when(genMock).generate(genMojo);
+
+    genMojo.execute();
+
+    verify(genMock).generate(genMojo);
+  }
+}

--- a/src/test/java/com/google/cloud/tools/maven/GenRepoInfoFileMojoTest.java
+++ b/src/test/java/com/google/cloud/tools/maven/GenRepoInfoFileMojoTest.java
@@ -13,7 +13,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.Mockito;
 import org.mockito.runners.MockitoJUnitRunner;
 
 import java.nio.file.Paths;

--- a/src/test/java/com/google/cloud/tools/maven/it/AbstractMojoIntegrationTest.java
+++ b/src/test/java/com/google/cloud/tools/maven/it/AbstractMojoIntegrationTest.java
@@ -16,10 +16,15 @@
 
 package com.google.cloud.tools.maven.it;
 
+import com.google.cloud.tools.appengine.cloudsdk.CloudSdk;
+import com.google.cloud.tools.appengine.cloudsdk.internal.process.ProcessRunnerException;
+import com.google.cloud.tools.appengine.cloudsdk.process.NonZeroExceptionExitListener;
 import com.google.cloud.tools.maven.it.verifier.TailingVerifier;
 
 import org.apache.maven.it.VerificationException;
 import org.junit.BeforeClass;
+
+import java.util.Arrays;
 
 public abstract class AbstractMojoIntegrationTest {
 
@@ -34,5 +39,12 @@ public abstract class AbstractMojoIntegrationTest {
       verifier.executeGoal("install");
       doneInstallPlugin = true;
     }
+  }
+
+  protected void deleteService(String service) throws ProcessRunnerException {
+    CloudSdk cloudSdk = new CloudSdk.Builder()
+        .exitListener(new NonZeroExceptionExitListener())
+        .build();
+    cloudSdk.runAppCommand(Arrays.asList("services", "delete", service));
   }
 }

--- a/src/test/java/com/google/cloud/tools/maven/it/DeployMojoIntegrationTest.java
+++ b/src/test/java/com/google/cloud/tools/maven/it/DeployMojoIntegrationTest.java
@@ -16,9 +16,7 @@
 
 package com.google.cloud.tools.maven.it;
 
-import com.google.cloud.tools.appengine.cloudsdk.CloudSdk;
 import com.google.cloud.tools.appengine.cloudsdk.internal.process.ProcessRunnerException;
-import com.google.cloud.tools.appengine.cloudsdk.process.NonZeroExceptionExitListener;
 import com.google.cloud.tools.maven.it.verifier.FlexibleVerifier;
 import com.google.cloud.tools.maven.it.verifier.StandardVerifier;
 
@@ -27,7 +25,6 @@ import org.apache.maven.it.Verifier;
 import org.junit.Test;
 
 import java.io.IOException;
-import java.util.Arrays;
 
 public class DeployMojoIntegrationTest extends AbstractMojoIntegrationTest {
 
@@ -65,12 +62,5 @@ public class DeployMojoIntegrationTest extends AbstractMojoIntegrationTest {
 
     // cleanup
     deleteService("flexible-project");
-  }
-
-  private void deleteService(String service) throws ProcessRunnerException {
-    CloudSdk cloudSdk = new CloudSdk.Builder()
-        .exitListener(new NonZeroExceptionExitListener())
-        .build();
-    cloudSdk.runAppCommand(Arrays.asList("services", "delete", service));
   }
 }

--- a/src/test/java/com/google/cloud/tools/maven/it/DeployMojoIntegrationTest.java
+++ b/src/test/java/com/google/cloud/tools/maven/it/DeployMojoIntegrationTest.java
@@ -60,6 +60,10 @@ public class DeployMojoIntegrationTest extends AbstractMojoIntegrationTest {
     verifier.verifyTextInLog("Detected App Engine flexible environment application");
     verifier.verifyTextInLog("GCLOUD: Deployed service");
 
+    // verify debugger required file generation
+    verifier.assertFilePresent("target/flexible-project-1.0-SNAPSHOT/WEB-INF/classes/"
+        + "source-context.json");
+
     // cleanup
     deleteService("flexible-project");
   }

--- a/src/test/java/com/google/cloud/tools/maven/it/GenRepoInfoFileMojoIntegrationTest.java
+++ b/src/test/java/com/google/cloud/tools/maven/it/GenRepoInfoFileMojoIntegrationTest.java
@@ -23,6 +23,17 @@ public class GenRepoInfoFileMojoIntegrationTest extends AbstractMojoIntegrationT
   }
 
   /**
+   * Ensures that this goal is ran with the package phase.
+   */
+  @Test
+  public void testGenerateCallingPackage() throws IOException, VerificationException {
+    Verifier verifier = new StandardVerifier("testGenRepoInfoFile");
+
+    verifier.executeGoal("package");
+    verifier.assertFilePresent("target/appengine-staging/WEB-INF/classes/source-context.json");
+  }
+
+  /**
    * Ensures that the genRepoInfoFile goal is automatically called for a flexible project
    * deployment.
    */

--- a/src/test/java/com/google/cloud/tools/maven/it/GenRepoInfoFileMojoIntegrationTest.java
+++ b/src/test/java/com/google/cloud/tools/maven/it/GenRepoInfoFileMojoIntegrationTest.java
@@ -1,5 +1,6 @@
 package com.google.cloud.tools.maven.it;
 
+import com.google.cloud.tools.maven.it.verifier.FlexibleVerifier;
 import com.google.cloud.tools.maven.it.verifier.StandardVerifier;
 
 import org.apache.maven.it.VerificationException;
@@ -18,5 +19,17 @@ public class GenRepoInfoFileMojoIntegrationTest extends AbstractMojoIntegrationT
 
     verifier.executeGoal("appengine:genRepoInfoFile");
     verifier.assertFilePresent("target/appengine-staging/WEB-INF/classes/source-context.json");
+  }
+
+  /**
+   * Ensures that the genRepoInfoFile goal is automatically called for a flexible project deployment
+   */
+  @Test
+  public void testGenerateFlex() throws VerificationException, IOException {
+    Verifier verifier = new FlexibleVerifier("testGenRepoInfoFile_flex");
+
+    verifier.executeGoal("appengine:deploy");
+    verifier.assertFilePresent("target/flexible-project-1.0-SNAPSHOT/WEB-INF/classes/"
+        + "source-context.json");
   }
 }

--- a/src/test/java/com/google/cloud/tools/maven/it/GenRepoInfoFileMojoIntegrationTest.java
+++ b/src/test/java/com/google/cloud/tools/maven/it/GenRepoInfoFileMojoIntegrationTest.java
@@ -1,5 +1,6 @@
 package com.google.cloud.tools.maven.it;
 
+import com.google.cloud.tools.appengine.cloudsdk.internal.process.ProcessRunnerException;
 import com.google.cloud.tools.maven.it.verifier.FlexibleVerifier;
 import com.google.cloud.tools.maven.it.verifier.StandardVerifier;
 
@@ -22,14 +23,17 @@ public class GenRepoInfoFileMojoIntegrationTest extends AbstractMojoIntegrationT
   }
 
   /**
-   * Ensures that the genRepoInfoFile goal is automatically called for a flexible project deployment
+   * Ensures that the genRepoInfoFile goal is automatically called for a flexible project
+   * deployment.
    */
   @Test
-  public void testGenerateFlex() throws VerificationException, IOException {
+  public void testGenerateFlex() throws VerificationException, IOException, ProcessRunnerException {
     Verifier verifier = new FlexibleVerifier("testGenRepoInfoFile_flex");
 
     verifier.executeGoal("appengine:deploy");
     verifier.assertFilePresent("target/flexible-project-1.0-SNAPSHOT/WEB-INF/classes/"
         + "source-context.json");
+
+    deleteService("flexible-project");
   }
 }

--- a/src/test/java/com/google/cloud/tools/maven/it/GenRepoInfoFileMojoIntegrationTest.java
+++ b/src/test/java/com/google/cloud/tools/maven/it/GenRepoInfoFileMojoIntegrationTest.java
@@ -1,0 +1,19 @@
+package com.google.cloud.tools.maven.it;
+
+import com.google.cloud.tools.maven.it.verifier.StandardVerifier;
+import org.apache.maven.it.VerificationException;
+import org.apache.maven.it.Verifier;
+
+import java.io.IOException;
+
+/**
+ * {@link com.google.cloud.tools.maven.GenRepoInfoFileMojo} integration tests.
+ */
+public class GenRepoInfoFileMojoIntegrationTest extends AbstractMojoIntegrationTest {
+  public void testGenerate() throws IOException, VerificationException {
+    Verifier verifier = new StandardVerifier("testGenRepoInfoFile");
+
+    verifier.executeGoal("appengine:genRepoInfoFile");
+    verifier.assertFileMatches();
+  }
+}

--- a/src/test/java/com/google/cloud/tools/maven/it/GenRepoInfoFileMojoIntegrationTest.java
+++ b/src/test/java/com/google/cloud/tools/maven/it/GenRepoInfoFileMojoIntegrationTest.java
@@ -32,19 +32,4 @@ public class GenRepoInfoFileMojoIntegrationTest extends AbstractMojoIntegrationT
     verifier.executeGoal("package");
     verifier.assertFilePresent("target/appengine-staging/WEB-INF/classes/source-context.json");
   }
-
-  /**
-   * Ensures that the genRepoInfoFile goal is automatically called for a flexible project
-   * deployment.
-   */
-  @Test
-  public void testGenerateFlex() throws VerificationException, IOException, ProcessRunnerException {
-    Verifier verifier = new FlexibleVerifier("testGenRepoInfoFile_flex");
-
-    verifier.executeGoal("appengine:deploy");
-    verifier.assertFilePresent("target/flexible-project-1.0-SNAPSHOT/WEB-INF/classes/"
-        + "source-context.json");
-
-    deleteService("flexible-project");
-  }
 }

--- a/src/test/java/com/google/cloud/tools/maven/it/GenRepoInfoFileMojoIntegrationTest.java
+++ b/src/test/java/com/google/cloud/tools/maven/it/GenRepoInfoFileMojoIntegrationTest.java
@@ -1,8 +1,10 @@
 package com.google.cloud.tools.maven.it;
 
 import com.google.cloud.tools.maven.it.verifier.StandardVerifier;
+
 import org.apache.maven.it.VerificationException;
 import org.apache.maven.it.Verifier;
+import org.junit.Test;
 
 import java.io.IOException;
 
@@ -10,10 +12,11 @@ import java.io.IOException;
  * {@link com.google.cloud.tools.maven.GenRepoInfoFileMojo} integration tests.
  */
 public class GenRepoInfoFileMojoIntegrationTest extends AbstractMojoIntegrationTest {
+  @Test
   public void testGenerate() throws IOException, VerificationException {
     Verifier verifier = new StandardVerifier("testGenRepoInfoFile");
 
     verifier.executeGoal("appengine:genRepoInfoFile");
-    verifier.assertFileMatches();
+    verifier.assertFilePresent("target/appengine-staging/WEB-INF/classes/source-context.json");
   }
 }

--- a/src/test/resources/projects/flexible-project/pom.xml
+++ b/src/test/resources/projects/flexible-project/pom.xml
@@ -23,6 +23,14 @@
         <version>${appengine-maven-plugin.version}</version>
         <configuration>
         </configuration>
+        <executions>
+          <execution>
+            <phase>prepare-package</phase>
+            <goals>
+              <goal>genRepoInfoFile</goal>
+            </goals>
+          </execution>
+        </executions>
       </plugin>
     </plugins>
   </build>


### PR DESCRIPTION
Fixes #100.

This should be ready for early preview. I think I still need to add unit tests here.

For the generation to be done automatically, this has the sad shortcoming that the following needs to be added to the pom.xml of the project using the plugin:

      <plugin>
        <groupId>com.google.cloud.tools</groupId>
        <artifactId>appengine-maven-plugin</artifactId>
        <version>1.0.0-SNAPSHOT</version>

>         <executions>
>           <execution>
>             <phase>prepare-package</phase>
>             <goals>
>               <goal>genRepoInfoFile</goal>
>             </goals>
>           </execution>
>         </executions>

      </plugin>