### PR TITLE
Force correct maven-compiler-plugin version on integration tests.

### DIFF
--- a/src/test/resources/projects/parent/pom.xml
+++ b/src/test/resources/projects/parent/pom.xml
@@ -61,6 +61,15 @@
         <artifactId>maven-war-plugin</artifactId>
         <version>2.1</version>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.5.1</version>
+        <configuration>
+          <source>1.7</source>
+          <target>1.7</target>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 


### PR DESCRIPTION
Integration tests are all failing on my local environment because an ancient version of the maven compiler was being selected by default.