### PR TITLE
Allow app.yaml to be generated by gcloud when deploying

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -105,7 +105,7 @@
     <dependency>
       <groupId>com.google.cloud.tools</groupId>
       <artifactId>appengine-plugins-core</artifactId>
-      <version>0.2.7-SNAPSHOT</version>
+      <version>0.2.7</version>
     </dependency>
 
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -105,7 +105,7 @@
     <dependency>
       <groupId>com.google.cloud.tools</groupId>
       <artifactId>appengine-plugins-core</artifactId>
-      <version>0.2.6</version>
+      <version>0.2.7-SNAPSHOT</version>
     </dependency>
 
     <dependency>

--- a/src/main/java/com/google/cloud/tools/maven/DeployMojo.java
+++ b/src/main/java/com/google/cloud/tools/maven/DeployMojo.java
@@ -96,6 +96,8 @@ public class DeployMojo extends StageMojo implements DeployConfiguration {
     File appYamlFile = new File(getStagingDirectory() + "/app.yaml");
     if (deployables.size() == 0 && appYamlFile.exists()) {
       deployables.add(appYamlFile);
+    } else {
+      deployables.add(stagingDirectory);
     }
 
     getAppEngineFactory().deployment().deploy(this);

--- a/src/main/java/com/google/cloud/tools/maven/DeployMojo.java
+++ b/src/main/java/com/google/cloud/tools/maven/DeployMojo.java
@@ -93,7 +93,7 @@ public class DeployMojo extends StageMojo implements DeployConfiguration {
     // execute stage
     super.execute();
 
-    File appYamlFile = new File(getStagingDirectory() + "/app.yaml");
+    File appYamlFile = new File(stagingDirectory + "/app.yaml");
     if (deployables.size() == 0 && appYamlFile.exists()) {
       deployables.add(appYamlFile);
     } else {

--- a/src/main/java/com/google/cloud/tools/maven/DeployMojo.java
+++ b/src/main/java/com/google/cloud/tools/maven/DeployMojo.java
@@ -93,9 +93,9 @@ public class DeployMojo extends StageMojo implements DeployConfiguration {
     // execute stage
     super.execute();
 
-    if (deployables.size() == 0) {
-      deployables.add(
-          new File(getStagingDirectory() + "/app.yaml"));
+    File appYamlFile = new File(getStagingDirectory() + "/app.yaml");
+    if (deployables.size() == 0 && appYamlFile.exists()) {
+      deployables.add(appYamlFile);
     }
 
     getAppEngineFactory().deployment().deploy(this);

--- a/src/test/java/com/google/cloud/tools/maven/DeployMojoTest.java
+++ b/src/test/java/com/google/cloud/tools/maven/DeployMojoTest.java
@@ -90,7 +90,7 @@ public class DeployMojoTest {
     deployMojo.execute();
 
     // verify
-    assertEquals(0, deployMojo.deployables.size());
+    assertEquals(1, deployMojo.deployables.size());
     verify(standardStagingMock).stageStandard(deployMojo);
     verify(deploymentMock).deploy(deployMojo);
   }
@@ -106,7 +106,8 @@ public class DeployMojoTest {
     deployMojo.execute();
 
     // verify
-    assertEquals(0, deployMojo.deployables.size());
+    assertEquals(1, deployMojo.deployables.size());
+    assertEquals(deployMojo.stagingDirectory, deployMojo.deployables.get(0));
     verify(flexibleStagingMock).stageFlexible(deployMojo);
     verify(deploymentMock).deploy(deployMojo);
   }

--- a/src/test/java/com/google/cloud/tools/maven/DeployMojoTest.java
+++ b/src/test/java/com/google/cloud/tools/maven/DeployMojoTest.java
@@ -90,7 +90,7 @@ public class DeployMojoTest {
     deployMojo.execute();
 
     // verify
-    assertEquals(1, deployMojo.deployables.size());
+    assertEquals(0, deployMojo.deployables.size());
     verify(standardStagingMock).stageStandard(deployMojo);
     verify(deploymentMock).deploy(deployMojo);
   }
@@ -106,7 +106,7 @@ public class DeployMojoTest {
     deployMojo.execute();
 
     // verify
-    assertEquals(1, deployMojo.deployables.size());
+    assertEquals(0, deployMojo.deployables.size());
     verify(flexibleStagingMock).stageFlexible(deployMojo);
     verify(deploymentMock).deploy(deployMojo);
   }


### PR DESCRIPTION
Fixes #131.

This is pending fix in appengine-plugins-core: https://github.com/GoogleCloudPlatform/appengine-plugins-core/issues/317