### PR TITLE
update plugins-core to 0.3.2, add <environment> parameter

### DIFF
--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -214,7 +214,7 @@ To switch back to the Dev App Server v2-alpha (that was default in version < 1.3
 
 ### How can I pass environment variables to the Dev Appserver (both v1 and v2-alpha)?
 
-You can debug the Dev App Server v1 using the jvmFlags:
+You can pass environment variables directly to the Dev App Server:
 
 ```XML
 <configuration>

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -78,13 +78,13 @@ Valid for versions "1" and "2-alpha":
 | Parameter             | Description |
 | --------------------- | ----------- |
 | ~~`appYamls`~~        | Deprecated in favor of `services` |
-| `jvmFlags`            | JVM flags to pass to the App Server Java process. |
-| `host`                | Application host address. |
-| `port`                | Application host port. |
-| `startSuccessTimeout` | Amount of time in seconds to wait for the Dev App Server to start in the background. |
 | `devserverVersion`    | Server versions to use, options are "1" or "2-alpha" |
-| `services`            | List of services to run |
 | `environment`        | Environment variables to pass to the Dev App Server process |
+| `host`                | Application host address. |
+| `jvmFlags`            | JVM flags to pass to the App Server Java process. |
+| `port`                | Application host port. |
+| `services`            | List of services to run |
+| `startSuccessTimeout` | Amount of time in seconds to wait for the Dev App Server to start in the background. |
 
 Only valid for version "2-alpha":
 

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -84,6 +84,7 @@ Valid for versions "1" and "2-alpha":
 | `startSuccessTimeout` | Amount of time in seconds to wait for the Dev App Server to start in the background. |
 | `devserverVersion`    | Server versions to use, options are "1" or "2-alpha" |
 | `services`            | List of services to run |
+| `environment`        | Environment variables to pass to the Dev App Server process |
 
 Only valid for version "2-alpha":
 
@@ -209,6 +210,18 @@ To switch back to the Dev App Server v2-alpha (that was default in version < 1.3
 <configuration>
    <devserverVersion>2-alpha</devserverVersion>
 </configuration>
+```
+
+### How can I pass environment variables to the Dev Appserver (both v1 and v2-alpha)?
+
+You can debug the Dev App Server v1 using the jvmFlags:
+
+```XML
+<configuration>
+  <environment>
+    <VARIABLE_NAME>value</VARIABLE_NAME>
+  <environment>
+<configuration>
 ```
 
 ---

--- a/pom.xml
+++ b/pom.xml
@@ -105,7 +105,7 @@
     <dependency>
       <groupId>com.google.cloud.tools</groupId>
       <artifactId>appengine-plugins-core</artifactId>
-      <version>0.3.1</version>
+      <version>0.3.2</version>
     </dependency>
 
     <dependency>

--- a/src/main/java/com/google/cloud/tools/maven/CloudSdkAppEngineFactory.java
+++ b/src/main/java/com/google/cloud/tools/maven/CloudSdkAppEngineFactory.java
@@ -23,8 +23,8 @@ import com.google.cloud.tools.appengine.api.deploy.AppEngineStandardStaging;
 import com.google.cloud.tools.appengine.api.devserver.AppEngineDevServer;
 import com.google.cloud.tools.appengine.cloudsdk.CloudSdk;
 import com.google.cloud.tools.appengine.cloudsdk.CloudSdkAppEngineDeployment;
-import com.google.cloud.tools.appengine.cloudsdk.CloudSdkAppEngineDevServer;
 import com.google.cloud.tools.appengine.cloudsdk.CloudSdkAppEngineDevServer1;
+import com.google.cloud.tools.appengine.cloudsdk.CloudSdkAppEngineDevServer2;
 import com.google.cloud.tools.appengine.cloudsdk.CloudSdkAppEngineFlexibleStaging;
 import com.google.cloud.tools.appengine.cloudsdk.CloudSdkAppEngineStandardStaging;
 import com.google.cloud.tools.appengine.cloudsdk.CloudSdkGenRepoInfoFile;
@@ -154,7 +154,7 @@ public class CloudSdkAppEngineFactory implements AppEngineFactory {
     }
 
     public AppEngineDevServer devServer(CloudSdk cloudSdk) {
-      return new CloudSdkAppEngineDevServer(cloudSdk);
+      return new CloudSdkAppEngineDevServer2(cloudSdk);
     }
 
     public AppEngineDevServer devServer1(CloudSdk cloudSdk) {

--- a/src/main/java/com/google/cloud/tools/maven/RunMojo.java
+++ b/src/main/java/com/google/cloud/tools/maven/RunMojo.java
@@ -31,6 +31,7 @@ import org.apache.maven.plugins.annotations.Parameter;
 import java.io.File;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Run App Engine Development App Server synchronously.
@@ -265,6 +266,9 @@ public class RunMojo extends CloudSdkMojo implements RunConfiguration {
   @Parameter(alias = "devserver.clearDatastore", property = "app.devserver.clearDatastore")
   protected Boolean clearDatastore;
 
+  @Parameter(alias = "devserver.environment", property = "app.devserver.environment")
+  private Map<String, String> environment;
+
   // RunAsyncMojo should override #runServer(version) so that other configuration changing code 
   // shared between these classes is executed 
   @Override
@@ -465,5 +469,10 @@ public class RunMojo extends CloudSdkMojo implements RunConfiguration {
   @Override
   public File getDatastorePath() {
     return datastorePath;
+  }
+
+  @Override
+  public Map<String, String> getEnvironment() {
+    return environment;
   }
 }

--- a/src/main/java/com/google/cloud/tools/maven/RunMojo.java
+++ b/src/main/java/com/google/cloud/tools/maven/RunMojo.java
@@ -270,7 +270,7 @@ public class RunMojo extends CloudSdkMojo implements RunConfiguration {
    * Environment variables passed to the devappserver process.
    */
   @Parameter(alias = "devserver.environment", property = "app.devserver.environment")
-  private Map<String, String> environment;
+  protected Map<String, String> environment;
 
   // RunAsyncMojo should override #runServer(version) so that other configuration changing code 
   // shared between these classes is executed 

--- a/src/main/java/com/google/cloud/tools/maven/RunMojo.java
+++ b/src/main/java/com/google/cloud/tools/maven/RunMojo.java
@@ -266,6 +266,9 @@ public class RunMojo extends CloudSdkMojo implements RunConfiguration {
   @Parameter(alias = "devserver.clearDatastore", property = "app.devserver.clearDatastore")
   protected Boolean clearDatastore;
 
+  /**
+   * Environment variables passed to the devappserver process.
+   */
   @Parameter(alias = "devserver.environment", property = "app.devserver.environment")
   private Map<String, String> environment;
 

--- a/src/test/java/com/google/cloud/tools/maven/it/RunAsyncMojoIntegrationTest.java
+++ b/src/test/java/com/google/cloud/tools/maven/it/RunAsyncMojoIntegrationTest.java
@@ -16,7 +16,9 @@
 
 package com.google.cloud.tools.maven.it;
 
+import static org.hamcrest.core.StringContains.containsString;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 import com.google.cloud.tools.maven.AppEngineFactory.SupportedDevServerVersion;
@@ -61,8 +63,9 @@ public class RunAsyncMojoIntegrationTest extends AbstractMojoIntegrationTest {
     verifier.setSystemProperty("app.devserver.startSuccessTimeout", "60");
     verifier.executeGoal("appengine:start");
 
-    assertEquals("Hello from the App Engine Standard project.",
-        UrlUtils.getUrlContentWithRetries(getServerUrl(), 60000, 1000));
+    String urlContent = UrlUtils.getUrlContentWithRetries(getServerUrl(), 60000, 1000);
+    assertThat(urlContent, containsString("Hello from the App Engine Standard project."));
+    assertThat(urlContent, containsString("TEST_VAR=testVariableValue"));
     verifier.verifyErrorFreeLog();
     verifier.verifyTextInLog("Dev App Server is now running");
     } finally {

--- a/src/test/java/com/google/cloud/tools/maven/it/RunAsyncMojoIntegrationTest.java
+++ b/src/test/java/com/google/cloud/tools/maven/it/RunAsyncMojoIntegrationTest.java
@@ -17,7 +17,6 @@
 package com.google.cloud.tools.maven.it;
 
 import static org.hamcrest.core.StringContains.containsString;
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 

--- a/src/test/java/com/google/cloud/tools/maven/it/RunMojoIntegrationTest.java
+++ b/src/test/java/com/google/cloud/tools/maven/it/RunMojoIntegrationTest.java
@@ -16,14 +16,16 @@
 
 package com.google.cloud.tools.maven.it;
 
+import static org.hamcrest.core.StringContains.containsString;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 import com.google.cloud.tools.maven.AppEngineFactory.SupportedDevServerVersion;
 import com.google.cloud.tools.maven.it.util.UrlUtils;
 import com.google.cloud.tools.maven.it.verifier.StandardVerifier;
 import com.google.cloud.tools.maven.util.SocketUtil;
-
+import com.google.common.base.Strings;
 import org.apache.maven.it.VerificationException;
 import org.apache.maven.it.Verifier;
 import org.junit.Before;
@@ -58,7 +60,8 @@ public class RunMojoIntegrationTest extends AbstractMojoIntegrationTest {
   @Test
   @Parameters
   public void testRun(final SupportedDevServerVersion version, String[] profiles,
-      String expectedModuleName) throws IOException, VerificationException, InterruptedException {
+      String expectedModuleName)
+          throws IOException, VerificationException, InterruptedException {
 
     final String name = "testRun" + version + Arrays.toString(profiles);
     final Verifier verifier = createVerifier(name, version);
@@ -98,8 +101,9 @@ public class RunMojoIntegrationTest extends AbstractMojoIntegrationTest {
 
     thread.join();
 
-    // verify
-    assertEquals("Hello from the App Engine Standard project.", urlContent.toString());
+    assertThat(urlContent.toString(),
+        containsString("Hello from the App Engine Standard project."));
+    assertThat(urlContent.toString(), containsString("TEST_VAR=testVariableValue"));
     verifier.verifyErrorFreeLog();
     verifier.verifyTextInLog("Dev App Server is now running");
     verifier.verifyTextInLog("Module instance " + expectedModuleName + " is running");

--- a/src/test/resources/projects/standard-project/pom.xml
+++ b/src/test/resources/projects/standard-project/pom.xml
@@ -26,6 +26,9 @@
             <!-- required for kokoro gcp_ubuntu b/37217450 -->
             <jvmFlag>-Djava.security.egd=file:/dev/urandom</jvmFlag>
           </jvmFlags>
+          <environment>
+            <TEST_VAR>testVariableValue</TEST_VAR>
+          </environment>
         </configuration>
       </plugin>
     </plugins>

--- a/src/test/resources/projects/standard-project/src/main/java/HelloServlet.java
+++ b/src/test/resources/projects/standard-project/src/main/java/HelloServlet.java
@@ -15,6 +15,7 @@ public class HelloServlet extends HttpServlet {
     resp.setHeader("Pragma", "no-cache"); // HTTP 1.0.
     resp.setHeader("Expires", "0"); // Proxies.
 
+    resp.getWriter().print("TEST_VAR=" + System.getenv("TEST_VAR"));
     resp.getWriter().print("Hello from the App Engine Standard project.");
   }
 


### PR DESCRIPTION
I don't particularly like how the <environment> parameter is tested in the integration test, but until we add more thorough testing of parameters to integration tests, it'll be OK.