### PR TITLE
Upgrades appengine-plugins-core to 0.3.9 and adds support for new add…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+## 1.3.2
+### Added
+* New `<additionalArguments>` parameter to pass additional arguments to Dev App Server ([#219](../../pulls/219)),
+relevant pull request in App Engine Plugins Core:
+[appengine-plugins-core/433](https://github.com/GoogleCloudPlatform/appengine-plugins-core/pull/433)
+
+### Changed
+* Upgrade App Engine Plugins Core dependency to 0.3.9 ([#219](../../pulls/219))
+
 ## 1.3.1
 ### Added
 * New `<environment>` parameter to pass environment variables to Dev App Server ([#183](../../pulls/183)),

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -79,12 +79,13 @@ Valid for versions "1" and "2-alpha":
 | --------------------- | ----------- |
 | ~~`appYamls`~~        | Deprecated in favor of `services` |
 | `devserverVersion`    | Server versions to use, options are "1" or "2-alpha" |
-| `environment`        | Environment variables to pass to the Dev App Server process |
+| `environment`         | Environment variables to pass to the Dev App Server process |
 | `host`                | Application host address. |
 | `jvmFlags`            | JVM flags to pass to the App Server Java process. |
 | `port`                | Application host port. |
 | `services`            | List of services to run |
 | `startSuccessTimeout` | Amount of time in seconds to wait for the Dev App Server to start in the background. |
+| `additionalArguments` | Any additional arguments to be passed to the Dev App Server |
 
 Only valid for version "2-alpha":
 
@@ -234,7 +235,20 @@ You can pass environment variables directly to the Dev App Server:
 <configuration>
   <environment>
     <VARIABLE_NAME>value</VARIABLE_NAME>
-  <environment>
+  </environment>
+<configuration>
+```
+
+### How can I pass additional arguments to the Dev Appserver (both v1 and v2-alpha)?
+
+You can pass additional arguments directly to the Dev App Server:
+
+```XML
+<configuration>
+  <additionalArguments>
+    <additionalArgument>--ARG1</additionalArgument>
+    <additionalArgument>--ARG2</additionalArgument>
+  </additionalArguments>
 <configuration>
 ```
 

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -236,7 +236,7 @@ You can pass environment variables directly to the Dev App Server:
   <environment>
     <VARIABLE_NAME>value</VARIABLE_NAME>
   </environment>
-<configuration>
+</configuration>
 ```
 
 ### How can I pass additional arguments to the Dev Appserver (both v1 and v2-alpha)?
@@ -249,7 +249,7 @@ You can pass additional arguments directly to the Dev App Server:
     <additionalArgument>--ARG1</additionalArgument>
     <additionalArgument>--ARG2</additionalArgument>
   </additionalArguments>
-<configuration>
+</configuration>
 ```
 
 ---

--- a/pom.xml
+++ b/pom.xml
@@ -105,7 +105,7 @@
     <dependency>
       <groupId>com.google.cloud.tools</groupId>
       <artifactId>appengine-plugins-core</artifactId>
-      <version>0.3.2</version>
+      <version>0.3.9</version>
     </dependency>
 
     <dependency>

--- a/src/main/java/com/google/cloud/tools/maven/RunMojo.java
+++ b/src/main/java/com/google/cloud/tools/maven/RunMojo.java
@@ -272,6 +272,12 @@ public class RunMojo extends CloudSdkMojo implements RunConfiguration {
   @Parameter(alias = "devserver.environment", property = "app.devserver.environment")
   protected Map<String, String> environment;
 
+  /**
+   * Environment variables passed to the devappserver process.
+   */
+  @Parameter(alias = "devserver.additionalArguments", property = "app.devserver.additionalArguments")
+  protected List<String> additionalArguments;
+
   // RunAsyncMojo should override #runServer(version) so that other configuration changing code 
   // shared between these classes is executed 
   @Override
@@ -477,5 +483,10 @@ public class RunMojo extends CloudSdkMojo implements RunConfiguration {
   @Override
   public Map<String, String> getEnvironment() {
     return environment;
+  }
+
+  @Override
+  public List<String> getAdditionalArguments() {
+    return additionalArguments;
   }
 }

--- a/src/main/java/com/google/cloud/tools/maven/RunMojo.java
+++ b/src/main/java/com/google/cloud/tools/maven/RunMojo.java
@@ -275,7 +275,8 @@ public class RunMojo extends CloudSdkMojo implements RunConfiguration {
   /**
    * Environment variables passed to the devappserver process.
    */
-  @Parameter(alias = "devserver.additionalArguments", property = "app.devserver.additionalArguments")
+  @Parameter(alias = "devserver.additionalArguments",
+      property = "app.devserver.additionalArguments")
   protected List<String> additionalArguments;
 
   // RunAsyncMojo should override #runServer(version) so that other configuration changing code 


### PR DESCRIPTION
First step of #217 . This adds support for additional arguments to pass to dev app server that was added in https://github.com/GoogleCloudPlatform/appengine-plugins-core/issues/432.