### PR TITLE
Update appengine plugins core

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -105,7 +105,7 @@
     <dependency>
       <groupId>com.google.cloud.tools</groupId>
       <artifactId>appengine-plugins-core</artifactId>
-      <version>0.3.9</version>
+      <version>0.5.0</version>
     </dependency>
 
     <dependency>

--- a/src/main/java/com/google/cloud/tools/maven/AbstractSingleYamlDeployMojo.java
+++ b/src/main/java/com/google/cloud/tools/maven/AbstractSingleYamlDeployMojo.java
@@ -33,6 +33,10 @@ public abstract class AbstractSingleYamlDeployMojo extends StageMojo
   @Parameter(alias = "deploy.project", property = "app.deploy.project")
   protected String project;
 
+  /** The App Engine server to connect to. You will not typically need to change this value. */
+  @Parameter(alias = "deploy.server", property = "app.deploy.server")
+  protected String server;
+
   public AbstractSingleYamlDeployMojo() {
     super();
   }
@@ -74,5 +78,10 @@ public abstract class AbstractSingleYamlDeployMojo extends StageMojo
   @Override
   public String getProject() {
     return project;
+  }
+
+  @Override
+  public String getServer() {
+    return server;
   }
 }


### PR DESCRIPTION
Adds the `getServer()` method to the `DeployProjectConfigurationConfiguration` interface.