### PR TITLE
Upgrade Mockito and plugins / clean up warnings

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -104,7 +104,7 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
-      <version>2.0.54-beta</version>
+      <version>2.23.4</version>
       <scope>test</scope>
     </dependency>
 
@@ -168,8 +168,9 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.5.1</version>
+        <version>3.8.0</version>
         <configuration>
+          <!-- Use <release> instead when migrating to JDK 11. -->
           <source>1.8</source>
           <target>1.8</target>
         </configuration>
@@ -265,7 +266,7 @@
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>findbugs-maven-plugin</artifactId>
-        <version>3.0.3</version>
+        <version>3.0.5</version>
         <configuration>
           <excludeFilterFile>findbugs-exclude.xml</excludeFilterFile>
         </configuration>
@@ -306,7 +307,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>2.19.1</version>
+        <version>2.22.1</version>
         <configuration>
           <excludes>
             <exclude>**/*IntegrationTest.java</exclude>
@@ -318,7 +319,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-failsafe-plugin</artifactId>
-        <version>2.19.1</version>
+        <version>2.22.1</version>
         <configuration>
           <includes>
             <include>**/*IntegrationTest.java</include>
@@ -343,7 +344,7 @@
       <plugin>
         <groupId>org.jacoco</groupId>
         <artifactId>jacoco-maven-plugin</artifactId>
-        <version>0.7.7.201606060606</version>
+        <version>0.8.2</version>
         <executions>
           <execution>
             <goals>

--- a/src/test/java/com/google/cloud/tools/maven/cloudsdk/CloudSdkAppEngineFactoryTest.java
+++ b/src/test/java/com/google/cloud/tools/maven/cloudsdk/CloudSdkAppEngineFactoryTest.java
@@ -30,8 +30,6 @@ import com.google.cloud.tools.appengine.operations.cloudsdk.CloudSdkOutOfDateExc
 import com.google.cloud.tools.appengine.operations.cloudsdk.CloudSdkVersionFileException;
 import com.google.cloud.tools.appengine.operations.cloudsdk.process.ProcessHandler;
 import com.google.cloud.tools.maven.cloudsdk.CloudSdkAppEngineFactory.SupportedDevServerVersion;
-import java.io.File;
-import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import org.apache.maven.model.Build;
@@ -46,7 +44,7 @@ import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
 public class CloudSdkAppEngineFactoryTest {
@@ -73,22 +71,16 @@ public class CloudSdkAppEngineFactoryTest {
   @InjectMocks private CloudSdkAppEngineFactory factory;
 
   @Before
-  public void wireUp() throws IOException {
+  public void wireUp() {
     when(mojoMock.getCloudSdkHome()).thenReturn(CLOUD_SDK_HOME);
     when(mojoMock.getCloudSdkVersion()).thenReturn(null);
     when(mojoMock.getArtifactId()).thenReturn(ARTIFACT_ID);
     when(mojoMock.getArtifactVersion()).thenReturn(ARTIFACT_VERSION);
     when(mojoMock.getLog()).thenReturn(logMock);
 
-    when(mojoMock.getMavenProject()).thenReturn(projectMock);
-    when(projectMock.getBuild()).thenReturn(buildMock);
-    File outFolder = tempFolder.newFolder("tempOut");
-    when(buildMock.getDirectory()).thenReturn(outFolder.getAbsolutePath());
-
     doReturn(INSTALL_SDK_PATH)
         .when(cloudSdkDownloader)
-        .downloadIfNecessary(
-            Mockito.isNull(String.class), Mockito.eq(logMock), Mockito.anyBoolean());
+        .downloadIfNecessary(Mockito.isNull(), Mockito.eq(logMock), Mockito.anyBoolean());
     doReturn(INSTALL_SDK_PATH)
         .when(cloudSdkDownloader)
         .downloadIfNecessary(Mockito.anyString(), Mockito.eq(logMock), Mockito.anyBoolean());

--- a/src/test/java/com/google/cloud/tools/maven/cloudsdk/CloudSdkCheckerTest.java
+++ b/src/test/java/com/google/cloud/tools/maven/cloudsdk/CloudSdkCheckerTest.java
@@ -30,7 +30,7 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
 public class CloudSdkCheckerTest {

--- a/src/test/java/com/google/cloud/tools/maven/cloudsdk/CloudSdkDownloaderTest.java
+++ b/src/test/java/com/google/cloud/tools/maven/cloudsdk/CloudSdkDownloaderTest.java
@@ -16,6 +16,7 @@
 
 package com.google.cloud.tools.maven.cloudsdk;
 
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -38,7 +39,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
 public class CloudSdkDownloaderTest {
@@ -57,7 +58,6 @@ public class CloudSdkDownloaderTest {
   @Before
   public void setup() {
     when(managedCloudSdkFactory.apply(version)).thenReturn(managedCloudSdk);
-    when(managedCloudSdkFactory.apply(null)).thenReturn(managedCloudSdk);
     when(managedCloudSdk.newInstaller()).thenReturn(installer);
     when(managedCloudSdk.newComponentInstaller()).thenReturn(componentInstaller);
     when(managedCloudSdk.newUpdater()).thenReturn(updater);
@@ -85,7 +85,7 @@ public class CloudSdkDownloaderTest {
   public void testDownloadCloudSdk_ignoreAppEngineComponent()
       throws ManagedSdkVerificationException, ManagedSdkVersionMismatchException {
     when(managedCloudSdk.isInstalled()).thenReturn(true);
-    when(managedCloudSdk.hasComponent(SdkComponent.APP_ENGINE_JAVA)).thenReturn(false);
+    lenient().when(managedCloudSdk.hasComponent(SdkComponent.APP_ENGINE_JAVA)).thenReturn(false);
     downloader.downloadIfNecessary(version, log, false);
     verify(managedCloudSdk, never()).newInstaller();
     verify(managedCloudSdk, never()).newComponentInstaller();

--- a/src/test/java/com/google/cloud/tools/maven/cloudsdk/CloudSdkMojoTest.java
+++ b/src/test/java/com/google/cloud/tools/maven/cloudsdk/CloudSdkMojoTest.java
@@ -16,7 +16,7 @@
 
 package com.google.cloud.tools.maven.cloudsdk;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.when;
 
 import org.apache.maven.plugin.MojoExecutionException;
@@ -27,7 +27,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
 public class CloudSdkMojoTest {
@@ -61,7 +61,7 @@ public class CloudSdkMojoTest {
   }
 
   @Test
-  public void testGetPackaging() throws Exception {
+  public void testGetPackaging() {
     when(mavenProject.getPackaging()).thenReturn("this-is-a-test-packaging");
 
     assertEquals("this-is-a-test-packaging", mojo.getMavenProject().getPackaging());

--- a/src/test/java/com/google/cloud/tools/maven/config/AppEngineWebXmlConfigProcessorTest.java
+++ b/src/test/java/com/google/cloud/tools/maven/config/AppEngineWebXmlConfigProcessorTest.java
@@ -28,7 +28,7 @@ import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
 public class AppEngineWebXmlConfigProcessorTest {

--- a/src/test/java/com/google/cloud/tools/maven/config/AppYamlConfigProcessorTest.java
+++ b/src/test/java/com/google/cloud/tools/maven/config/AppYamlConfigProcessorTest.java
@@ -29,7 +29,7 @@ import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
 public class AppYamlConfigProcessorTest {

--- a/src/test/java/com/google/cloud/tools/maven/deploy/AbstractDeployMojoTest.java
+++ b/src/test/java/com/google/cloud/tools/maven/deploy/AbstractDeployMojoTest.java
@@ -22,7 +22,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
 public class AbstractDeployMojoTest {

--- a/src/test/java/com/google/cloud/tools/maven/deploy/DeployAllMojoTest.java
+++ b/src/test/java/com/google/cloud/tools/maven/deploy/DeployAllMojoTest.java
@@ -22,7 +22,7 @@ import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
 public class DeployAllMojoTest {

--- a/src/test/java/com/google/cloud/tools/maven/deploy/DeployCronMojoTest.java
+++ b/src/test/java/com/google/cloud/tools/maven/deploy/DeployCronMojoTest.java
@@ -22,7 +22,7 @@ import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
 public class DeployCronMojoTest {

--- a/src/test/java/com/google/cloud/tools/maven/deploy/DeployDispatchMojoTest.java
+++ b/src/test/java/com/google/cloud/tools/maven/deploy/DeployDispatchMojoTest.java
@@ -22,7 +22,7 @@ import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
 public class DeployDispatchMojoTest {

--- a/src/test/java/com/google/cloud/tools/maven/deploy/DeployDosMojoTest.java
+++ b/src/test/java/com/google/cloud/tools/maven/deploy/DeployDosMojoTest.java
@@ -22,7 +22,7 @@ import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
 public class DeployDosMojoTest {

--- a/src/test/java/com/google/cloud/tools/maven/deploy/DeployIndexMojoTest.java
+++ b/src/test/java/com/google/cloud/tools/maven/deploy/DeployIndexMojoTest.java
@@ -22,7 +22,7 @@ import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
 public class DeployIndexMojoTest {

--- a/src/test/java/com/google/cloud/tools/maven/deploy/DeployMojoTest.java
+++ b/src/test/java/com/google/cloud/tools/maven/deploy/DeployMojoTest.java
@@ -22,7 +22,7 @@ import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
 public class DeployMojoTest {

--- a/src/test/java/com/google/cloud/tools/maven/deploy/DeployQueueMojoTest.java
+++ b/src/test/java/com/google/cloud/tools/maven/deploy/DeployQueueMojoTest.java
@@ -22,7 +22,7 @@ import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
 public class DeployQueueMojoTest {

--- a/src/test/java/com/google/cloud/tools/maven/genrepoinfo/GenRepoInfoFileMojoTest.java
+++ b/src/test/java/com/google/cloud/tools/maven/genrepoinfo/GenRepoInfoFileMojoTest.java
@@ -16,7 +16,7 @@
 
 package com.google.cloud.tools.maven.genrepoinfo;
 
-import static org.mockito.Matchers.any;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -35,7 +35,7 @@ import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 /** {@link GenRepoInfoFileMojo} unit tests. */
 @RunWith(MockitoJUnitRunner.class)

--- a/src/test/java/com/google/cloud/tools/maven/run/RunAsyncMojoTest.java
+++ b/src/test/java/com/google/cloud/tools/maven/run/RunAsyncMojoTest.java
@@ -22,7 +22,7 @@ import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
 public class RunAsyncMojoTest {

--- a/src/test/java/com/google/cloud/tools/maven/run/RunMojoTest.java
+++ b/src/test/java/com/google/cloud/tools/maven/run/RunMojoTest.java
@@ -22,7 +22,7 @@ import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
 public class RunMojoTest {

--- a/src/test/java/com/google/cloud/tools/maven/stage/StagerTest.java
+++ b/src/test/java/com/google/cloud/tools/maven/stage/StagerTest.java
@@ -16,18 +16,15 @@
 
 package com.google.cloud.tools.maven.stage;
 
-import java.io.IOException;
-import java.nio.file.Path;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.junit.Assert;
-import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
 public class StagerTest {
@@ -35,12 +32,6 @@ public class StagerTest {
   @Rule public TemporaryFolder tempFolder = new TemporaryFolder();
 
   @Mock private AbstractStageMojo stageMojo;
-
-  @Before
-  public void setup() throws IOException {
-    Path sourceDirectory = tempFolder.newFolder("source").toPath();
-    Mockito.when(stageMojo.getSourceDirectory()).thenReturn(sourceDirectory);
-  }
 
   @Test
   public void testNewStager_noOpStager() throws MojoExecutionException {


### PR DESCRIPTION
In preparation for building on JDK 11.

Upgrades Mockito and some plugins. Some tests were failing after upgrading Mockito because of unnecessary stubbing. I removed them but used `Mockito.lenient()` in one place to suppress the error, which seemed meaningful have the stubbing.

This will allow building on JDK 11 almost successfully, but unfortunately, the dev appserver v2 doesn't seem to run on JVM 11, so integration tests with dev appserver v2 fail. Not sure if recent Cloud SDK versions ship with Java 11 compatible dev appserver v2 and our tests were merely pulling in an old Cloud SDK, but I haven't gone that far to figure out if it is the case.