### PR TITLE
Remove Cobertura

### DIFF
--- a/kokoro/continuous.bat
+++ b/kokoro/continuous.bat
@@ -7,7 +7,7 @@ cd github/app-maven-plugin
 call gcloud.cmd components update --quiet
 call gcloud.cmd components install app-engine-java --quiet
 
-call mvnw.cmd clean install cobertura:cobertura -B -U
+call mvnw.cmd clean install -B -U
 REM curl -s https://codecov.io/bash | bash
 
 exit /b %ERRORLEVEL%

--- a/kokoro/continuous.sh
+++ b/kokoro/continuous.sh
@@ -9,5 +9,5 @@ sudo /opt/google-cloud-sdk/bin/gcloud components update
 sudo /opt/google-cloud-sdk/bin/gcloud components install app-engine-java
 
 cd github/app-maven-plugin
-./mvnw clean install cobertura:cobertura -B -U
+./mvnw clean install -B -U
 # bash <(curl -s https://codecov.io/bash)

--- a/kokoro/continuous_mac.sh
+++ b/kokoro/continuous_mac.sh
@@ -17,5 +17,5 @@ M2_HOME="$(pwd)"/apache-maven-3.5.0
 PATH=$PATH:$M2_HOME/bin
 
 cd github/app-maven-plugin
-./mvnw clean install cobertura:cobertura -B -U
+./mvnw clean install -B -U
 # bash <(curl -s https://codecov.io/bash)


### PR DESCRIPTION
Cobertura can't handle Java 8 code, and `./mvnw -U cobertura:cobertura` is failing. Cobertura has been dormant for years regarding Java 8 support and seems almost dead.