### PR TITLE
Rearrage docs, add faq for thin jars

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,8 +34,8 @@ You can now run commands like `mvn package appengine:deploy` in the root folder 
 
 Please see the [USER GUIDE](USER_GUIDE.md) for a full list of supported goals and configuration
 options.
-* [for app.yaml based projects](USER_GUIDE.md#app-engine-appengine-webxml-based-projects)
-* [for appengine-web.xml based projects](USER_GUIDE.md#app-engine-appyaml-based-project)
+* [USER\_GUIDE for `app.yaml` based projects](USER_GUIDE.md#app-engine-appyaml-based-projects)
+* [USER\_GUIDE for `appengine-web.xml` based projects](USER_GUIDE.md#app-engine-appengine-webxml-based-project)
 
 # Reference Documentation
 

--- a/README.md
+++ b/README.md
@@ -5,10 +5,6 @@
 
 This Maven plugin provides goals to build and deploy Google App Engine applications.
 
-| 2.0.0 is Live |
-| :------------------------------ |
-| 2.0.0 has been published. The behavior of the appengine-maven-plugin has changed since v1.+; please see the [CHANGELOG](CHANGELOG.md) for a full list of changes and an updated [USER GUIDE](USER_GUIDE.md) for details. If you are having trouble using or updating your plugin, please file a [new issue](https://github.com/GoogleCloudPlatform/app-maven-plugin/issues).|
-
 # Requirements
 
 [Maven](http://maven.apache.org/) is required to build and run the plugin.

--- a/README.md
+++ b/README.md
@@ -9,29 +9,12 @@ This Maven plugin provides goals to build and deploy Google App Engine applicati
 | :------------------------------ |
 | 2.0.0 has been published. The behavior of the appengine-maven-plugin has changed since v1.+; please see the [CHANGELOG](CHANGELOG.md) for a full list of changes and an updated [USER GUIDE](USER_GUIDE.md) for details. If you are having trouble using or updating your plugin, please file a [new issue](https://github.com/GoogleCloudPlatform/app-maven-plugin/issues).|
 
-# Reference Documentation
-
-App Engine Standard Environment:
-* [Using Apache Maven and the App Engine Plugin (standard environment)](https://cloud.google.com/appengine/docs/java/tools/using-maven)
-* [App Engine Maven Plugin Goals and Parameters (standard environment)](https://cloud.google.com/appengine/docs/java/tools/maven-reference)
-
-App Engine Flexible Environment:
-* [Using Apache Maven and the App Engine Plugin (flexible environment)](https://cloud.google.com/appengine/docs/flexible/java/using-maven)
-* [App Engine Maven Plugin Goals and Parameters (flexible environment)](https://cloud.google.com/appengine/docs/flexible/java/maven-reference)
-
 # Requirements
 
 [Maven](http://maven.apache.org/) is required to build and run the plugin.
 
-You must have [Google Cloud SDK](https://cloud.google.com/sdk/) installed.
-
-Cloud SDK app-engine-java component is also required. Install it by running:
-
-    gcloud components install app-engine-java
-
-Login and configure Cloud SDK:
-
-    gcloud init
+[Google Cloud SDK](https://cloud.google.com/sdk/) is required but will be
+automatically installed by the plugin.
 
 # How to use
 
@@ -47,38 +30,19 @@ In your Maven App Engine Java app, add the following plugin to your pom.xml:
 
 You can now run commands like `mvn package appengine:deploy` in the root folder of your Java application.
 
-# Supported goals
+## Goals and Configuration
 
-Goal | Description
---- | ---
-appengine:cloudSdkLogin|Login and set the Cloud SDK common configuration user.
-appengine:stage|Generates an application directory for deployment.
-appengine:deploy|Stages and deploys an application to App Engine.
-appengine:deployCron|Deploy cron configuration.
-appengine:deployDispatch|Deploy dispatch configuration.
-appengine:deployDos|Deploy dos configuration.
-appengine:deployIndex|Deploy datastore index configuration.
-appengine:deployQueue|Deploy queue configuration.
-appengine:deployAll|Deploy the application with all available valid configuration.
-appengine:run|Runs the App Engine local development server. *(App Engine Standard Only)*
-appengine:start|Starts running the App Engine devserver asynchronously and then returns to the command line. When this goal runs, the behavior is the same as the run goal except that Maven continues processing goals and exits after the server is up and running. *(App Engine Standard Only)*
-appengine:stop|Stops a running App Engine web development server. *(App Engine Standard Only)*
-appengine:genRepoInfoFile|Generates source context files for use by Stackdriver Debugger.
-appengine:help|Displays help information on the plugin. Use `mvn appengine:help -Ddetail=true -Dgoal=[goal]` for detailed goal documentation.
+Please see the [USER GUIDE](USER_GUIDE.md) for a full list of supported goals and configuration
+options.
+* [for app.yaml based projects](USER_GUIDE.md#app-engine-appengine-webxml-based-projects)
+* [for appengine-web.xml based projects](USER_GUIDE.md#app-engine-appyaml-based-project)
 
-To automatically run the `appengine:genRepoInfoFile` goal during the Maven build workflow, add the following to your plugin executions section:
+# Reference Documentation
 
-```XML
-<plugin>
-  ...
-  <executions>
-    <execution>
-      <phase>prepare-package</phase>
-      <goals>
-        <goal>genRepoInfoFile</goal>
-      </goals>
-    </execution>
-  </executions>
-  ...
-</plugin>
-```
+App Engine Standard Environment:
+* [Using Apache Maven and the App Engine Plugin (standard environment)](https://cloud.google.com/appengine/docs/java/tools/using-maven)
+* [App Engine Maven Plugin Goals and Parameters (standard environment)](https://cloud.google.com/appengine/docs/java/tools/maven-reference)
+
+App Engine Flexible Environment:
+* [Using Apache Maven and the App Engine Plugin (flexible environment)](https://cloud.google.com/appengine/docs/flexible/java/using-maven)
+* [App Engine Maven Plugin Goals and Parameters (flexible environment)](https://cloud.google.com/appengine/docs/flexible/java/maven-reference)

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -368,4 +368,41 @@ The plugin defaults to `appengine-web.xml` based deployment if your project cont
 file. If your project also has an `src/main/appengine/app.yaml` file and you wish to use that, you may temporarily move the
 `appengine-web.xml` file to a different location before deploying.
 
+### How do I deploy an `app.yaml` based thin jar to appengine?
+
+You will probably need to stage the application to include it's dependencies. You might use something like the
+[`maven-dependency-plugin:copy-dependency`](https://maven.apache.org/plugins/maven-dependency-plugin/copy-dependencies-mojo.html)
+goal to copy dependencies into a directory and then configure that directory to be staged with your application using
+the `extraFilesDirectories` parameter. For example:
+
+```xml
+<plugin>
+  <artifactId>maven-dependency-plugin</artifactId>
+  <executions>
+    <execution>
+      <phase>package</phase>
+      <goals>
+        <goal>copy-dependencies</goal>
+      </goals>
+      <configuration>
+        <outputDirectory>${project.build.directory}/dependencies</outputDirectory>
+      </configuration>
+    </execution>
+  </executions>
+</plugin>
+<plugin>
+  <groupId>com.google.cloud.tools</groupId>
+  <artifactId>appengine-maven-plugin</artifactId>
+  <version>2.1.0</version>
+  <configuration>
+    <!-- your config -->
+    <extraFilesDirectories>
+       <extraFilesDirectory>${project.build.directory}/dependencies</extraFilesDirectory>
+    </extraFilesDirectories>
+  </configuration>
+</plugin>
+```
+
+Then when you run `mvn package appengine:deploy` the dependencies are copied and included as part of the deployment.
+
 ---

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -399,13 +399,13 @@ the `extraFilesDirectories` parameter in the appengine plugin. For example:
   <configuration>
     <!-- your config -->
     <extraFilesDirectories>
-       <extraFilesDirectory>${project.build.directory}/dependencies</extraFilesDirectory>
+      <extraFilesDirectory>${project.build.directory}/dependencies</extraFilesDirectory>
     </extraFilesDirectories>
   </configuration>
 </plugin>
 ```
 
-Then when you run `mvn package appengine:deploy` the dependencies are copied and included as part of the deployment
+Then when you run `mvn package appengine:deploy` the dependencies are copied and included as part of the deployment.
 
 Since the default entrypoint assumes a fat jar, you must define a custom entrypoint to run this application. In this
 example we might have an `app.yaml` that looks like:

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -368,12 +368,14 @@ The plugin defaults to `appengine-web.xml` based deployment if your project cont
 file. If your project also has an `src/main/appengine/app.yaml` file and you wish to use that, you may temporarily move the
 `appengine-web.xml` file to a different location before deploying.
 
-### How do I deploy an `app.yaml` based thin jar to appengine?
+### How do I deploy a thin jar to App Engine?
 
-You will probably need to stage the application to include it's dependencies. You might use something like the
+You can do this if you have an `app.yaml` based project and you have a custom `entrypoint` configured to start it.
+
+You will need to configure the stage goal to include your project's dependencies. You could use something like the
 [`maven-dependency-plugin:copy-dependency`](https://maven.apache.org/plugins/maven-dependency-plugin/copy-dependencies-mojo.html)
 goal to copy dependencies into a directory and then configure that directory to be staged with your application using
-the `extraFilesDirectories` parameter. For example:
+the `extraFilesDirectories` parameter in the appengine plugin. For example:
 
 ```xml
 <plugin>
@@ -403,6 +405,14 @@ the `extraFilesDirectories` parameter. For example:
 </plugin>
 ```
 
-Then when you run `mvn package appengine:deploy` the dependencies are copied and included as part of the deployment.
+Then when you run `mvn package appengine:deploy` the dependencies are copied and included as part of the deployment
+
+Since the default entrypoint assumes a fat jar, you must define a custom entrypoint to run this application. In this
+example we might have an `app.yaml` that looks like:
+
+```
+runtime: java11
+entrypoint: java -Xmx64m -cp "*" com.example.MyMainClass
+```
 
 ---


### PR DESCRIPTION
You can see the rendered docs on the branch:
* readme: https://github.com/GoogleCloudPlatform/app-maven-plugin/blob/rearrange-docs/README.md
* user_guide: https://github.com/GoogleCloudPlatform/app-maven-plugin/blob/rearrange-docs/USER_GUIDE.md
