### PR TITLE
Upgrade plugins-core to 0.8.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -93,7 +93,7 @@
     <dependency>
       <groupId>com.google.cloud.tools</groupId>
       <artifactId>appengine-plugins-core</artifactId>
-      <version>0.7.6</version>
+      <version>0.8.1</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
Adds extended support for thin jar deployments, automatically copying
jars referenced in Class-Path in the source artifact to the staging
directory.

@ludoch this is all we would need to support this feature in 2.2.0