### PR TITLE
Handle empty service config better

### DIFF
--- a/src/main/java/com/google/cloud/tools/maven/run/AbstractRunMojo.java
+++ b/src/main/java/com/google/cloud/tools/maven/run/AbstractRunMojo.java
@@ -19,9 +19,12 @@ package com.google.cloud.tools.maven.run;
 import com.google.cloud.tools.maven.cloudsdk.CloudSdkMojo;
 import java.io.File;
 import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
+import org.apache.maven.model.Build;
 import org.apache.maven.plugins.annotations.Parameter;
 
 public abstract class AbstractRunMojo extends CloudSdkMojo {
@@ -77,11 +80,17 @@ public abstract class AbstractRunMojo extends CloudSdkMojo {
   @Parameter(alias = "devserver.projectId", property = "app.devserver.projectId")
   private String projectId;
 
-  /** Return a list of Paths, but can return also return an empty list or null. */
+  /**
+   * Return a list of Paths to services to run. If none are specified by the user, the default
+   * application directory in the build output is used.
+   */
   public List<Path> getServices() {
-    return (services == null)
-        ? null
-        : services.stream().map(File::toPath).collect(Collectors.toList());
+    if (services == null || services.isEmpty()) {
+      Build build = getMavenProject().getBuild();
+      return Collections.singletonList(
+          Paths.get(build.getDirectory()).resolve(build.getFinalName()));
+    }
+    return services.stream().map(File::toPath).collect(Collectors.toList());
   }
 
   public String getHost() {

--- a/src/main/java/com/google/cloud/tools/maven/run/Runner.java
+++ b/src/main/java/com/google/cloud/tools/maven/run/Runner.java
@@ -89,7 +89,8 @@ public class Runner {
   List<Path> processServices() throws MojoExecutionException {
     List<Path> services = runMojo.getServices();
 
-    Preconditions.checkState(services != null && !services.isEmpty(), "No services found to run");
+    Preconditions.checkState(services != null, "'services' is null") ;
+    Preconditions.checkState(!services.isEmpty(), "'services' is empty");
 
     // verify all are appengine-web.xml based applications
     for (Path service : services) {

--- a/src/main/java/com/google/cloud/tools/maven/run/Runner.java
+++ b/src/main/java/com/google/cloud/tools/maven/run/Runner.java
@@ -20,12 +20,10 @@ import com.google.cloud.tools.appengine.AppEngineException;
 import com.google.cloud.tools.appengine.configuration.RunConfiguration;
 import com.google.cloud.tools.maven.cloudsdk.ConfigReader;
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Preconditions;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.util.Collections;
 import java.util.List;
-import org.apache.maven.model.Build;
 import org.apache.maven.plugin.MojoExecutionException;
 
 public class Runner {
@@ -82,11 +80,6 @@ public class Runner {
     runMojo.getLog().info("Use the 'mvn appengine:stop' command to stop the server.");
   }
 
-  private Path getAppDir() {
-    Build build = runMojo.getMavenProject().getBuild();
-    return Paths.get(build.getDirectory()).resolve(build.getFinalName());
-  }
-
   static final String NON_STANDARD_APPLICATION_ERROR =
       "\nCould not find appengine-web.xml all services, perhaps you need to run "
           + "'mvn package appengine:run/start'."
@@ -94,11 +87,9 @@ public class Runner {
 
   @VisibleForTesting
   List<Path> processServices() throws MojoExecutionException {
-    Path appDir = getAppDir();
     List<Path> services = runMojo.getServices();
-    if (services == null || services.isEmpty()) {
-      return Collections.singletonList(appDir);
-    }
+
+    Preconditions.checkState(services != null && !services.isEmpty(), "No services found to run");
 
     // verify all are appengine-web.xml based applications
     for (Path service : services) {

--- a/src/main/java/com/google/cloud/tools/maven/run/Runner.java
+++ b/src/main/java/com/google/cloud/tools/maven/run/Runner.java
@@ -89,7 +89,7 @@ public class Runner {
   List<Path> processServices() throws MojoExecutionException {
     List<Path> services = runMojo.getServices();
 
-    Preconditions.checkState(services != null, "'services' is null") ;
+    Preconditions.checkState(services != null, "'services' is null");
     Preconditions.checkState(!services.isEmpty(), "'services' is empty");
 
     // verify all are appengine-web.xml based applications

--- a/src/test/java/com/google/cloud/tools/maven/run/AbstractRunMojoTest.java
+++ b/src/test/java/com/google/cloud/tools/maven/run/AbstractRunMojoTest.java
@@ -1,3 +1,68 @@
 package com.google.cloud.tools.maven.run;
 
-public class AbstractRunMojoTest {}
+import com.google.common.collect.ImmutableList;
+import java.io.File;
+import java.lang.reflect.Field;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+import org.apache.maven.model.Build;
+import org.apache.maven.project.MavenProject;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class AbstractRunMojoTest {
+  private static class AbstractRunMojoImpl extends AbstractRunMojo {
+    @Override
+    public void execute() {
+      // do nothing;
+    }
+
+    public void injectServices(List<File> services)
+        throws NoSuchFieldException, IllegalAccessException {
+      Field servicesField = AbstractRunMojo.class.getDeclaredField("services");
+      servicesField.setAccessible(true);
+      servicesField.set(this, services);
+    }
+  }
+
+  @Mock MavenProject mavenProject;
+
+  @InjectMocks private final AbstractRunMojoImpl testMojo = new AbstractRunMojoImpl();
+
+  @Before
+  public void setUp() {
+    Build build = Mockito.mock(Build.class);
+    Mockito.when(mavenProject.getBuild()).thenReturn(build);
+    Mockito.when(build.getDirectory()).thenReturn("fake-build-dir");
+    Mockito.when(build.getFinalName()).thenReturn("fake-final-name");
+  }
+
+  @Test
+  public void testGetServices_null() throws NoSuchFieldException, IllegalAccessException {
+    testMojo.injectServices(null);
+    List<Path> expected = ImmutableList.of(Paths.get("fake-build-dir/fake-final-name"));
+    Assert.assertEquals(expected, testMojo.getServices());
+  }
+
+  @Test
+  public void testGetServices_empty() throws NoSuchFieldException, IllegalAccessException {
+    testMojo.injectServices(ImmutableList.of());
+    List<Path> expected = ImmutableList.of(Paths.get("fake-build-dir/fake-final-name"));
+    Assert.assertEquals(expected, testMojo.getServices());
+  }
+
+  @Test
+  public void testGetServices_validList() throws NoSuchFieldException, IllegalAccessException {
+    testMojo.injectServices(ImmutableList.of(new File("some-service-location")));
+    Assert.assertEquals(
+        ImmutableList.of(Paths.get("some-service-location")), testMojo.getServices());
+  }
+}

--- a/src/test/java/com/google/cloud/tools/maven/run/AbstractRunMojoTest.java
+++ b/src/test/java/com/google/cloud/tools/maven/run/AbstractRunMojoTest.java
@@ -1,0 +1,3 @@
+package com.google.cloud.tools.maven.run;
+
+public class AbstractRunMojoTest {}

--- a/src/test/java/com/google/cloud/tools/maven/run/AbstractRunMojoTest.java
+++ b/src/test/java/com/google/cloud/tools/maven/run/AbstractRunMojoTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 Google LLC. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.google.cloud.tools.maven.run;
 
 import com.google.common.collect.ImmutableList;
@@ -33,7 +49,7 @@ public class AbstractRunMojoTest {
     }
   }
 
-  @Mock MavenProject mavenProject;
+  @Mock private MavenProject mavenProject;
 
   @InjectMocks private final AbstractRunMojoImpl testMojo = new AbstractRunMojoImpl();
 

--- a/src/test/java/com/google/cloud/tools/maven/run/RunnerTest.java
+++ b/src/test/java/com/google/cloud/tools/maven/run/RunnerTest.java
@@ -18,13 +18,11 @@ package com.google.cloud.tools.maven.run;
 
 import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.contains;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.google.cloud.tools.appengine.AppEngineException;
 import com.google.cloud.tools.appengine.operations.DevServer;
-import com.google.cloud.tools.appengine.operations.Gcloud;
 import com.google.cloud.tools.maven.cloudsdk.CloudSdkAppEngineFactory;
 import com.google.cloud.tools.maven.cloudsdk.ConfigReader;
 import com.google.cloud.tools.maven.run.Runner.ConfigBuilder;
@@ -34,10 +32,8 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
-import org.apache.maven.model.Build;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.logging.Log;
-import org.apache.maven.project.MavenProject;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
@@ -63,10 +59,8 @@ public class RunnerTest {
 
   @Mock private CloudSdkAppEngineFactory appengineFactory;
   @Mock private DevServer devServer;
-  @Mock private MavenProject mavenProject;
   @Mock private Log logMock;
   @Mock private ConfigReader configReader;
-  @Mock private Gcloud gcloud;
   private Path appDir;
 
   @Mock private ConfigBuilder configBuilder;
@@ -76,11 +70,6 @@ public class RunnerTest {
   @Before
   public void setUp() throws IOException {
     appDir = tempFolder.newFolder("artifact").toPath();
-    when(mavenProject.getBuild()).thenReturn(mock(Build.class));
-    when(mavenProject.getBuild().getDirectory())
-        .thenReturn(appDir.getParent().toAbsolutePath().toString());
-    when(mavenProject.getBuild().getFinalName()).thenReturn(appDir.getFileName().toString());
-    when(runMojo.getMavenProject()).thenReturn(mavenProject);
     when(runMojo.getLog()).thenReturn(logMock);
     when(runMojo.getAppEngineFactory()).thenReturn(appengineFactory);
     when(appengineFactory.newConfigReader()).thenReturn(configReader);
@@ -96,6 +85,7 @@ public class RunnerTest {
 
     when(appengineFactory.devServerRunSync()).thenReturn(devServer);
     setUpAppEngineWebXml();
+    when(runMojo.getServices()).thenReturn(ImmutableList.of(appDir));
 
     testRunner.run();
 
@@ -108,6 +98,7 @@ public class RunnerTest {
 
     when(appengineFactory.devServerRunAsync(START_SUCCESS_TIMEOUT)).thenReturn(devServer);
     setUpAppEngineWebXml();
+    when(runMojo.getServices()).thenReturn(ImmutableList.of(appDir));
 
     testRunner.runAsync(START_SUCCESS_TIMEOUT);
 
@@ -120,16 +111,20 @@ public class RunnerTest {
   public void testProcessServices_singleService() throws MojoExecutionException {
     List<Path> userConfiguredServices = ImmutableList.of(STANDARD_PROJECT_WEBAPP);
     when(runMojo.getServices()).thenReturn(userConfiguredServices);
-    List<Path> processedServices = testRunner.processServices();
-    Assert.assertEquals(userConfiguredServices, processedServices);
+    testRunner.processServices();
+    // no exception pass
   }
 
   @Test
   public void testProcessServices_empty() throws MojoExecutionException {
     List<Path> userConfiguredServices = ImmutableList.of();
     when(runMojo.getServices()).thenReturn(userConfiguredServices);
-    List<Path> processedServices = testRunner.processServices();
-    Assert.assertEquals(ImmutableList.of(appDir), processedServices);
+    try {
+      testRunner.processServices();
+      fail();
+    } catch (IllegalStateException ex) {
+      Assert.assertEquals("No services found to run", ex.getMessage());
+    }
   }
 
   @Test
@@ -137,8 +132,8 @@ public class RunnerTest {
     List<Path> userConfiguredServices =
         ImmutableList.of(STANDARD_PROJECT_WEBAPP, STANDARD_PROJECT_WEBAPP2);
     when(runMojo.getServices()).thenReturn(userConfiguredServices);
-    List<Path> processedServices = testRunner.processServices();
-    Assert.assertEquals(userConfiguredServices, processedServices);
+    testRunner.processServices();
+    // no exception pass
   }
 
   @Test

--- a/src/test/java/com/google/cloud/tools/maven/run/RunnerTest.java
+++ b/src/test/java/com/google/cloud/tools/maven/run/RunnerTest.java
@@ -111,7 +111,7 @@ public class RunnerTest {
   public void testProcessServices_singleService() throws MojoExecutionException {
     List<Path> userConfiguredServices = ImmutableList.of(STANDARD_PROJECT_WEBAPP);
     when(runMojo.getServices()).thenReturn(userConfiguredServices);
-    testRunner.processServices();
+    Assert.assertEquals(userConfiguredServices, testRunner.processServices());
     // no exception pass
   }
 
@@ -132,7 +132,7 @@ public class RunnerTest {
     List<Path> userConfiguredServices =
         ImmutableList.of(STANDARD_PROJECT_WEBAPP, STANDARD_PROJECT_WEBAPP2);
     when(runMojo.getServices()).thenReturn(userConfiguredServices);
-    testRunner.processServices();
+    Assert.assertEquals(userConfiguredServices, testRunner.processServices());
     // no exception pass
   }
 

--- a/src/test/java/com/google/cloud/tools/maven/run/RunnerTest.java
+++ b/src/test/java/com/google/cloud/tools/maven/run/RunnerTest.java
@@ -116,6 +116,17 @@ public class RunnerTest {
   }
 
   @Test
+  public void testProcessServices_null() throws MojoExecutionException {
+    when(runMojo.getServices()).thenReturn(null);
+    try {
+      testRunner.processServices();
+      fail();
+    } catch (IllegalStateException ex) {
+      Assert.assertEquals("'services' is null", ex.getMessage());
+    }
+  }
+
+  @Test
   public void testProcessServices_empty() throws MojoExecutionException {
     List<Path> userConfiguredServices = ImmutableList.of();
     when(runMojo.getServices()).thenReturn(userConfiguredServices);
@@ -123,7 +134,7 @@ public class RunnerTest {
       testRunner.processServices();
       fail();
     } catch (IllegalStateException ex) {
-      Assert.assertEquals("No services found to run", ex.getMessage());
+      Assert.assertEquals("'services' is empty", ex.getMessage());
     }
   }
 


### PR DESCRIPTION
fixes the error message for non appengine-web.xml projects when not specifying a service.

https://github.com/GoogleCloudPlatform/app-maven-plugin/issues/421#issuecomment-642873454