### PR TITLE
Releasing version 2.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,18 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
+## 2.4.1
+### Changed
+* Update to appengine-plugins-core 0.9.5 ([#446](../../pull/446))
+  * Addresses the security advisories in the old commons-compress library ([appengine-plugins-core#875](
+    https://github.com/GoogleCloudPlatform/appengine-plugins-core/pull/875)).
+
 ## 2.4.0
 ### Added
 * `appengine.tools.verbosity` option for defining gcloud log verbosity ([#429](../../pull/429))
 
 ## 2.3.0
-### Added
+### Changed
 * Update to appengine-plugins-core 0.9.0 ([#422](../../pull/422))
   * Includes support for binary artifacts for app.yaml based deployments ([appengine-plugins-core:#840](https://github.com/GoogleCloudPlatform/appengine-plugins-core/issues/840))
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>com.google.cloud.tools</groupId>
   <artifactId>appengine-maven-plugin</artifactId>
-  <version>2.4.1</version>
+  <version>2.4.2-SNAPSHOT</version>
   <packaging>maven-plugin</packaging>
 
   <name>App Engine Maven Plugin</name>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>com.google.cloud.tools</groupId>
   <artifactId>appengine-maven-plugin</artifactId>
-  <version>2.4.1-SNAPSHOT</version>
+  <version>2.4.1</version>
   <packaging>maven-plugin</packaging>
 
   <name>App Engine Maven Plugin</name>


### PR DESCRIPTION
Releasing this plugin to use appengine-plugins-core 0.9.5. Added the changelog.