### PR TITLE
Throw exception when app.yaml doesn't exist

### DIFF
--- a/src/main/java/com/google/cloud/tools/maven/stage/AppYamlStager.java
+++ b/src/main/java/com/google/cloud/tools/maven/stage/AppYamlStager.java
@@ -42,6 +42,12 @@ public class AppYamlStager implements Stager {
     AppYamlProjectStageConfiguration config = configBuilder.buildConfiguration();
     Path stagingDirectory = config.getStagingDirectory();
 
+    // Look for app.yaml
+    Path appYaml = stageMojo.getStagingDirectory().resolve("app.yaml");
+    if (!Files.exists(appYaml)) {
+      throw new MojoExecutionException("Failed to stage all: could not find app.yaml.");
+    }
+
     stageMojo.getLog().info("Staging the application to: " + stagingDirectory);
     stageMojo.getLog().info("Detected App Engine app.yaml based application.");
 

--- a/src/test/java/com/google/cloud/tools/maven/stage/AppYamlStagerTest.java
+++ b/src/test/java/com/google/cloud/tools/maven/stage/AppYamlStagerTest.java
@@ -23,10 +23,13 @@ import com.google.cloud.tools.appengine.operations.AppYamlProjectStaging;
 import com.google.cloud.tools.maven.cloudsdk.CloudSdkAppEngineFactory;
 import com.google.cloud.tools.maven.stage.AppYamlStager.ConfigBuilder;
 import junitparams.JUnitParamsRunner;
+import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.logging.Log;
 import org.apache.maven.project.MavenProject;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
+import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
@@ -57,5 +60,17 @@ public class AppYamlStagerTest {
     when(appengineFactory.appYamlStaging()).thenReturn(staging);
     when(configBuilder.buildConfiguration()).thenReturn(stagingConfiguration);
     when(stagingConfiguration.getStagingDirectory()).thenReturn(tempFolder.getRoot().toPath());
+  }
+
+  @Test
+  public void noAppYaml() {
+    when(stageMojo.getStagingDirectory()).thenReturn(tempFolder.getRoot().toPath());
+    testStager = new AppYamlStager(stageMojo, configBuilder);
+
+    try {
+      testStager.stage();
+    } catch (MojoExecutionException ex) {
+      Assert.assertEquals("Failed to stage all: could not find app.yaml.", ex.getMessage());
+    }
   }
 }


### PR DESCRIPTION
Fixes GoogleCloudPlatform/appengine-plugins#990

## What changes were proposed in this pull request ?

The [Stager Interface](https://github.com/GoogleCloudPlatform/app-maven-plugin/blob/master/src/main/java/com/google/cloud/tools/maven/stage/Stager.java#L39#L42) only check `appengine-web.xml`, and it would work when both `app.yaml` and `appengine-web.xml` are missing.

This patch verified the existence of `app.yaml` in [`AppYamlStager#stage()`](https://github.com/GoogleCloudPlatform/app-maven-plugin/blob/master/src/main/java/com/google/cloud/tools/maven/stage/AppYamlStager.java#L41). 

**PS.** Let me steal the idea of snippet in [`AppDeployer`](https://github.com/GoogleCloudPlatform/app-maven-plugin/blob/master/src/main/java/com/google/cloud/tools/maven/deploy/AppDeployer.java#L68#L72)  : ) 

## How was this patch tested ?

Just touch new unit test. (Feel free to correct me if I miss something.)