### PR TITLE
Working version with Java 17

### DIFF
--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -39,6 +39,18 @@ For appengine-web.xml based projects the plugin exposes the following goals :
 | `start`           | Start the application in the background. |
 | `stop`            | Stop a running application. |
 
+NOTE: To run locally on Java 17, you'll need to add the following plugin configuration:
+
+```
+<configuration>
+  <jvmFlags>
+    <jvmFlag>--add-opens=java.base/java.net=ALL-UNNAMED</jvmFlag>
+    <jvmFlag>--add-opens=java.base/sun.net.www.protocol.http=ALL-UNNAMED</jvmFlag>
+    <jvmFlag>--add-opens=java.base/sun.net.www.protocol.https=ALL-UNNAMED</jvmFlag>
+  </jvmFlags>
+</plugin>
+```
+
 #### Deployment
 
 | Goal             | Description |

--- a/pom.xml
+++ b/pom.xml
@@ -151,7 +151,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-plugin-plugin</artifactId>
-        <version>3.6.0</version>
+        <version>3.6.4</version>
         <executions>
           <execution>
             <id>default-descriptor</id>
@@ -170,9 +170,10 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.8.0</version>
+        <version>3.10.1</version>
         <configuration>
           <!-- Use <release> instead when migrating to JDK 11. -->
+          <!-- TBD: is this still needed -->
           <source>1.8</source>
           <target>1.8</target>
         </configuration>
@@ -182,14 +183,14 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jar-plugin</artifactId>
-        <version>3.0.2</version>
+        <version>3.2.2</version>
       </plugin>
 
       <!-- Source files jar -->
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-source-plugin</artifactId>
-        <version>2.4</version>
+        <version>3.2.1</version>
         <executions>
           <execution>
             <id>attach-sources</id>
@@ -266,6 +267,7 @@
       </plugin>
 
       <!-- SpotBugs -->
+<!--
       <plugin>
         <groupId>com.github.spotbugs</groupId>
         <artifactId>spotbugs-maven-plugin</artifactId>
@@ -282,12 +284,13 @@
           </execution>
         </executions>
       </plugin>
+-->
 
       <!-- PMD -->
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-pmd-plugin</artifactId>
-        <version>3.6</version>
+        <version>3.16.0</version>
         <configuration>
           <linkXRef>false</linkXRef>
           <printFailingErrors>true</printFailingErrors>
@@ -310,7 +313,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>2.22.1</version>
+        <version>2.22.2</version>
         <configuration>
           <excludes>
             <exclude>**/*IntegrationTest.java</exclude>
@@ -322,7 +325,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-failsafe-plugin</artifactId>
-        <version>2.22.1</version>
+        <version>2.22.2</version>
         <configuration>
           <includes>
             <include>**/*IntegrationTest.java</include>
@@ -344,7 +347,7 @@
       </plugin>
 
       <!-- Code Coverage -->
-      <plugin>
+     <!-- <plugin>
         <groupId>org.jacoco</groupId>
         <artifactId>jacoco-maven-plugin</artifactId>
         <version>0.8.2</version>
@@ -367,7 +370,7 @@
             <exclude>**/*HelpMojo.*</exclude>
           </excludes>
         </configuration>
-      </plugin>
+      </plugin>-->
     </plugins>
   </build>
 
@@ -386,7 +389,7 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-javadoc-plugin</artifactId>
-            <version>2.10.3</version>
+            <version>3.3.2</version>
             <executions>
               <execution>
                 <id>attach-javadocs</id>

--- a/pom.xml
+++ b/pom.xml
@@ -173,7 +173,6 @@
         <version>3.10.1</version>
         <configuration>
           <!-- Use <release> instead when migrating to JDK 11. -->
-          <!-- TBD: is this still needed -->
           <source>1.8</source>
           <target>1.8</target>
         </configuration>
@@ -346,10 +345,10 @@
       </plugin>
 
       <!-- Code Coverage -->
-     <!-- <plugin>
+     <plugin>
         <groupId>org.jacoco</groupId>
         <artifactId>jacoco-maven-plugin</artifactId>
-        <version>0.8.2</version>
+        <version>0.8.7</version>
         <executions>
           <execution>
             <goals>
@@ -369,7 +368,7 @@
             <exclude>**/*HelpMojo.*</exclude>
           </excludes>
         </configuration>
-      </plugin>-->
+      </plugin>
     </plugins>
   </build>
 

--- a/pom.xml
+++ b/pom.xml
@@ -267,11 +267,10 @@
       </plugin>
 
       <!-- SpotBugs -->
-<!--
       <plugin>
         <groupId>com.github.spotbugs</groupId>
         <artifactId>spotbugs-maven-plugin</artifactId>
-        <version>3.1.10</version>
+        <version>4.2.3</version>
         <configuration>
           <excludeFilterFile>spotbugs-exclude.xml</excludeFilterFile>
         </configuration>
@@ -284,7 +283,7 @@
           </execution>
         </executions>
       </plugin>
--->
+
 
       <!-- PMD -->
       <plugin>

--- a/src/test/resources/projects/parent/pom.xml
+++ b/src/test/resources/projects/parent/pom.xml
@@ -54,17 +54,20 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jar-plugin</artifactId>
-        <version>2.3</version>
+        <version>3.2.2</version>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-war-plugin</artifactId>
-        <version>2.1</version>
+        <version>3.3.2</version>
+        <configuration>
+
+        </configuration>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.5.1</version>
+        <version>3.10.1</version>
         <configuration>
           <source>1.8</source>
           <target>1.8</target>

--- a/src/test/resources/projects/parent/pom.xml
+++ b/src/test/resources/projects/parent/pom.xml
@@ -60,9 +60,6 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-war-plugin</artifactId>
         <version>3.3.2</version>
-        <configuration>
-
-        </configuration>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/src/test/resources/projects/standard-project/pom.xml
+++ b/src/test/resources/projects/standard-project/pom.xml
@@ -66,12 +66,9 @@
                 <jvmFlag>-Djava.security.egd=file:/dev/urandom</jvmFlag>
 
                 <!-- Illegal reflective access disallowed since Java 16 -->
-                <jvmFlag>--add-opens</jvmFlag>
-                <jvmFlag>java.base/java.net=ALL-UNNAMED</jvmFlag>
-                <jvmFlag>--add-opens</jvmFlag>
-                <jvmFlag>java.base/sun.net.www.protocol.http=ALL-UNNAMED</jvmFlag>
-                <jvmFlag>--add-opens</jvmFlag>
-                <jvmFlag>java.base/sun.net.www.protocol.https=ALL-UNNAMED</jvmFlag>
+                <jvmFlag>--add-opens=java.base/java.net=ALL-UNNAMED</jvmFlag>
+                <jvmFlag>--add-opens=java.base/sun.net.www.protocol.http=ALL-UNNAMED</jvmFlag>
+                <jvmFlag>--add-opens=java.base/sun.net.www.protocol.https=ALL-UNNAMED</jvmFlag>
 
                 <jvmFlag>-Duser.timezone='GMT-5'</jvmFlag>
 

--- a/src/test/resources/projects/standard-project/pom.xml
+++ b/src/test/resources/projects/standard-project/pom.xml
@@ -27,7 +27,16 @@
           <jvmFlags>
             <!-- required for kokoro gcp_ubuntu b/37217450 -->
             <jvmFlag>-Djava.security.egd=file:/dev/urandom</jvmFlag>
+            <jvmFlag>--add-opens</jvmFlag>
+            <jvmFlag>java.base/java.net=ALL-UNNAMED</jvmFlag>
+            <jvmFlag>--add-opens</jvmFlag>
+            <jvmFlag>java.base/sun.net.www.protocol.http=ALL-UNNAMED</jvmFlag>
+            <jvmFlag>--add-opens</jvmFlag>
+            <jvmFlag>java.base/sun.net.www.protocol.https=ALL-UNNAMED</jvmFlag>
+            <jvmFlag>-Duser.timezone='GMT-5'</jvmFlag>
           </jvmFlags>
+
+
           <environment>
             <TEST_VAR>testVariableValue</TEST_VAR>
           </environment>
@@ -46,7 +55,7 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-war-plugin</artifactId>
-            <version>2.4</version>
+            <version>3.3.2</version>
             <configuration>
               <warSourceDirectory>${project.basedir}/src/main/${it.sourceWebAppDir}</warSourceDirectory>
               <webappDirectory>${project.build.directory}/${it.targetWebAppDir}</webappDirectory>

--- a/src/test/resources/projects/standard-project/pom.xml
+++ b/src/test/resources/projects/standard-project/pom.xml
@@ -14,39 +14,79 @@
   <packaging>war</packaging>
   <name>App Engine Standard Project</name>
 
-  <build>
-    <plugins>
-      <plugin>
-        <groupId>com.google.cloud.tools</groupId>
-        <artifactId>appengine-maven-plugin</artifactId>
-        <version>${appengine-maven-plugin.version}</version>
-        <configuration>
-          <version>1</version>
-          <project>travis-app-maven-plugin</project>
-          <version>GCLOUD_VERSION</version>
-          <jvmFlags>
-            <!-- required for kokoro gcp_ubuntu b/37217450 -->
-            <jvmFlag>-Djava.security.egd=file:/dev/urandom</jvmFlag>
-            <jvmFlag>--add-opens</jvmFlag>
-            <jvmFlag>java.base/java.net=ALL-UNNAMED</jvmFlag>
-            <jvmFlag>--add-opens</jvmFlag>
-            <jvmFlag>java.base/sun.net.www.protocol.http=ALL-UNNAMED</jvmFlag>
-            <jvmFlag>--add-opens</jvmFlag>
-            <jvmFlag>java.base/sun.net.www.protocol.https=ALL-UNNAMED</jvmFlag>
-            <jvmFlag>-Duser.timezone='GMT-5'</jvmFlag>
-          </jvmFlags>
-
-
-          <environment>
-            <TEST_VAR>testVariableValue</TEST_VAR>
-          </environment>
-          <project>travis-app-maven-plugin</project>
-        </configuration>
-      </plugin>
-    </plugins>
-  </build>
 
   <profiles>
+    <profile>
+      <id>java8_and_below</id>
+      <activation>
+        <jdk>[,8]</jdk>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>com.google.cloud.tools</groupId>
+            <artifactId>appengine-maven-plugin</artifactId>
+            <version>${appengine-maven-plugin.version}</version>
+            <configuration>
+              <version>1</version>
+              <project>travis-app-maven-plugin</project>
+              <version>GCLOUD_VERSION</version>
+              <jvmFlags>
+                <!-- required for kokoro gcp_ubuntu b/37217450 -->
+                <jvmFlag>-Djava.security.egd=file:/dev/urandom</jvmFlag>
+              </jvmFlags>
+
+              <environment>
+                <TEST_VAR>testVariableValue</TEST_VAR>
+              </environment>
+              <project>travis-app-maven-plugin</project>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+
+    <profile>
+      <id>java9_and_up</id>
+      <activation>
+        <jdk>[9,]</jdk>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>com.google.cloud.tools</groupId>
+            <artifactId>appengine-maven-plugin</artifactId>
+            <version>${appengine-maven-plugin.version}</version>
+            <configuration>
+              <version>1</version>
+              <project>travis-app-maven-plugin</project>
+              <version>GCLOUD_VERSION</version>
+              <jvmFlags>
+                <!-- required for kokoro gcp_ubuntu b/37217450 -->
+                <jvmFlag>-Djava.security.egd=file:/dev/urandom</jvmFlag>
+
+                <!-- Illegal reflective access disallowed since Java 16 -->
+                <jvmFlag>--add-opens</jvmFlag>
+                <jvmFlag>java.base/java.net=ALL-UNNAMED</jvmFlag>
+                <jvmFlag>--add-opens</jvmFlag>
+                <jvmFlag>java.base/sun.net.www.protocol.http=ALL-UNNAMED</jvmFlag>
+                <jvmFlag>--add-opens</jvmFlag>
+                <jvmFlag>java.base/sun.net.www.protocol.https=ALL-UNNAMED</jvmFlag>
+
+                <jvmFlag>-Duser.timezone='GMT-5'</jvmFlag>
+
+              </jvmFlags>
+
+              <environment>
+                <TEST_VAR>testVariableValue</TEST_VAR>
+              </environment>
+              <project>travis-app-maven-plugin</project>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+
     <!-- base profile for integration tests using services to configure devappserver -->
     <profile>
       <id>base-it-profile</id>


### PR DESCRIPTION
All the plugins are working. I upgraded findbugs to a version somewhat lower than the latest because the latest comes with deeper immutability analysis that's more involved to fix (and not clear it's worth fixing for stable, self-contained code).

The integration test using AppEngine local devserver had to pass the JPMS add-opens parameteres, since devserver does some access modification of JDK classes through reflection. Since JPMS is available only starting at Java 9, I split the sample application appengine plugin into two profiles activated by java versions.
Also, a timezone option needed to be passed to work around an NPE in devserver (it's been fixed in devserver since, but not released yet).