### PR TITLE
workaround for permission with updated workspace path

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: workaround for permissions
-        run:  git config --global --add safe.directory /github/workspace
+        run:  git config --global --add safe.directory /__w/app-maven-plugin/app-maven-plugin
         
       - name: Check out code
         uses: actions/checkout@v2.4.1


### PR DESCRIPTION
replacing /github/workspace with /__w/app-maven-plugin/app-maven-plugin