### PR TITLE
chore: remove workaround for java 17 add-opens

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ In your Maven App Engine Java app, add the following plugin to your pom.xml:
 <plugin>
     <groupId>com.google.cloud.tools</groupId>
     <artifactId>appengine-maven-plugin</artifactId>
-    <version>2.4.1</version>
+    <version>2.4.4</version>
 </plugin>
 ```
 

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -39,17 +39,6 @@ For appengine-web.xml based projects the plugin exposes the following goals :
 | `start`           | Start the application in the background. |
 | `stop`            | Stop a running application. |
 
-NOTE: To run locally on Java 17, you'll need to add the following plugin configuration:
-
-```
-<configuration>
-  <jvmFlags>
-    <jvmFlag>--add-opens=java.base/java.net=ALL-UNNAMED</jvmFlag>
-    <jvmFlag>--add-opens=java.base/sun.net.www.protocol.http=ALL-UNNAMED</jvmFlag>
-    <jvmFlag>--add-opens=java.base/sun.net.www.protocol.https=ALL-UNNAMED</jvmFlag>
-  </jvmFlags>
-</plugin>
-```
 
 #### Deployment
 


### PR DESCRIPTION
The add-opens are now added by appengine-plugins-core.