### PR TITLE
chore: clean up JAVA_HOME setup

### DIFF
--- a/kokoro/continuous.bat
+++ b/kokoro/continuous.bat
@@ -1,6 +1,5 @@
-REM Java 9 does not work with our build at the moment, so force java 8
-set JAVA_HOME=c:\program files\java\jdk1.8.0_152
-set PATH=%JAVA_HOME%\bin;%PATH%
+REM Use Java 8 for build
+echo %JAVA_HOME%
 
 cd github/app-maven-plugin
 


### PR DESCRIPTION
Fixes similar issue as https://github.com/GoogleCloudPlatform/appengine-plugins-core/pull/912