### PR TITLE
gcloud components update to use the quiet option

### DIFF
--- a/kokoro/continuous.sh
+++ b/kokoro/continuous.sh
@@ -6,7 +6,7 @@ set -e
 set -x
 
 sudo /opt/google-cloud-sdk/bin/gcloud components update --quiet
-sudo /opt/google-cloud-sdk/bin/gcloud components install app-engine-java
+sudo /opt/google-cloud-sdk/bin/gcloud components install app-engine-java --quiet
 
 cd github/app-maven-plugin
 ./mvnw clean install -B -U

--- a/kokoro/continuous.sh
+++ b/kokoro/continuous.sh
@@ -5,7 +5,7 @@ set -e
 # Display commands to stderr.
 set -x
 
-sudo /opt/google-cloud-sdk/bin/gcloud components update
+sudo /opt/google-cloud-sdk/bin/gcloud components update --quiet
 sudo /opt/google-cloud-sdk/bin/gcloud components install app-engine-java
 
 cd github/app-maven-plugin

--- a/kokoro/release_build.sh
+++ b/kokoro/release_build.sh
@@ -5,7 +5,7 @@ set -e
 # Display commands to stderr.
 set -x
 
-sudo -E /opt/google-cloud-sdk/bin/gcloud components update
+sudo -E /opt/google-cloud-sdk/bin/gcloud components update --quiet
 sudo -E /opt/google-cloud-sdk/bin/gcloud components install app-engine-java
 
 cd github/app-maven-plugin

--- a/kokoro/release_build.sh
+++ b/kokoro/release_build.sh
@@ -6,7 +6,7 @@ set -e
 set -x
 
 sudo -E /opt/google-cloud-sdk/bin/gcloud components update --quiet
-sudo -E /opt/google-cloud-sdk/bin/gcloud components install app-engine-java
+sudo -E /opt/google-cloud-sdk/bin/gcloud components install app-engine-java --quiet
 
 cd github/app-maven-plugin
 ./mvnw -Prelease -B -U verify

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>com.google.cloud.tools</groupId>
   <artifactId>appengine-maven-plugin</artifactId>
-  <version>2.4.5-SNAPSHOT</version>
+  <version>2.5.0</version>
   <packaging>maven-plugin</packaging>
 
   <name>App Engine Maven Plugin</name>


### PR DESCRIPTION
- preparing release 2.5.0
- gcloud components upgrade with quiet option

I created this branch based on the existing v2.5.0 tag, so that we can use the updated commit to invoke the release build (without the snapshot version).